### PR TITLE
feat: 방 생성,참가,수정 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.rest-assured:rest-assured:5.4.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/mafia/mafiatogether/config/WebMvcConfig.java
+++ b/src/main/java/mafia/mafiatogether/config/WebMvcConfig.java
@@ -1,0 +1,16 @@
+package mafia.mafiatogether.config;
+
+import java.util.List;
+import mafia.mafiatogether.controller.PlayerArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new PlayerArgumentResolver());
+    }
+}

--- a/src/main/java/mafia/mafiatogether/controller/PlayerArgumentResolver.java
+++ b/src/main/java/mafia/mafiatogether/controller/PlayerArgumentResolver.java
@@ -1,0 +1,45 @@
+package mafia.mafiatogether.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Base64;
+import mafia.mafiatogether.service.dto.PlayerInfoDto;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class PlayerArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(PlayerInfo.class);
+    }
+
+    @Override
+    public PlayerInfoDto resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
+                                         final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
+        HttpServletRequest httpServletRequest = webRequest.getNativeRequest(HttpServletRequest.class);
+
+        if (httpServletRequest == null) {
+            throw new IllegalArgumentException("HttpServletRequest를 찾을 수 없습니다.");
+        }
+
+        String authorization = httpServletRequest.getHeader("Authorization");
+        if (authorization == null) {
+            throw new IllegalArgumentException("인증 헤더가 없습니다.");
+        }
+
+        String[] token = authorization.split(" ");
+        if (token.length != 2 || !token[0].equals("Basic")) {
+            throw new IllegalArgumentException("올바른 인증 형식이 아닙니다.");
+        }
+
+        String[] info = new String(Base64.getDecoder().decode(token[1])).split(":");
+        if (info.length != 2) {
+            throw new IllegalArgumentException("올바른 인증 형식이 아닙니다.");
+        }
+
+        return new PlayerInfoDto(info[0], info[1]);
+    }
+}

--- a/src/main/java/mafia/mafiatogether/controller/PlayerInfo.java
+++ b/src/main/java/mafia/mafiatogether/controller/PlayerInfo.java
@@ -1,0 +1,11 @@
+package mafia.mafiatogether.controller;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PlayerInfo {
+}

--- a/src/main/java/mafia/mafiatogether/controller/RoomController.java
+++ b/src/main/java/mafia/mafiatogether/controller/RoomController.java
@@ -2,12 +2,15 @@ package mafia.mafiatogether.controller;
 
 import lombok.RequiredArgsConstructor;
 import mafia.mafiatogether.service.RoomService;
-import mafia.mafiatogether.service.dto.CreateRoomRequest;
-import mafia.mafiatogether.service.dto.CreateRoomResponse;
+import mafia.mafiatogether.service.dto.RoomCreateRequest;
+import mafia.mafiatogether.service.dto.RoomCreateResponse;
+import mafia.mafiatogether.service.dto.RoomStatusResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,7 +21,14 @@ public class RoomController {
     private final RoomService roomService;
 
     @PostMapping
-    public ResponseEntity<CreateRoomResponse> create(@RequestBody CreateRoomRequest request) {
+    public ResponseEntity<RoomCreateResponse> create(@RequestBody RoomCreateRequest request) {
         return ResponseEntity.ok(roomService.create(request));
+    }
+
+    @GetMapping("/status")
+    public ResponseEntity<RoomStatusResponse> findStatus(
+            @RequestParam("code") String code
+    ) {
+        return ResponseEntity.ok(roomService.findStatus(code));
     }
 }

--- a/src/main/java/mafia/mafiatogether/controller/RoomController.java
+++ b/src/main/java/mafia/mafiatogether/controller/RoomController.java
@@ -5,9 +5,11 @@ import mafia.mafiatogether.service.RoomService;
 import mafia.mafiatogether.service.dto.PlayerInfoDto;
 import mafia.mafiatogether.service.dto.RoomCreateRequest;
 import mafia.mafiatogether.service.dto.RoomCreateResponse;
+import mafia.mafiatogether.service.dto.RoomModifyRequest;
 import mafia.mafiatogether.service.dto.RoomStatusResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,5 +32,15 @@ public class RoomController {
             @PlayerInfo PlayerInfoDto playerInfoDto
     ) {
         return ResponseEntity.ok(roomService.findStatus(playerInfoDto.code()));
+    }
+
+
+    @PatchMapping("/status")
+    public ResponseEntity<Void> modifyStatus(
+            @PlayerInfo PlayerInfoDto playerInfoDto,
+            @RequestBody RoomModifyRequest request
+    ) {
+        roomService.modifyStatus(playerInfoDto.code(), request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/mafia/mafiatogether/controller/RoomController.java
+++ b/src/main/java/mafia/mafiatogether/controller/RoomController.java
@@ -1,0 +1,24 @@
+package mafia.mafiatogether.controller;
+
+import lombok.RequiredArgsConstructor;
+import mafia.mafiatogether.service.RoomService;
+import mafia.mafiatogether.service.dto.CreateRoomRequest;
+import mafia.mafiatogether.service.dto.CreateRoomResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/room")
+public class RoomController {
+
+    private final RoomService roomService;
+
+    @PostMapping
+    public ResponseEntity<CreateRoomResponse> create(@RequestBody CreateRoomRequest request) {
+        return ResponseEntity.ok(roomService.create(request));
+    }
+}

--- a/src/main/java/mafia/mafiatogether/controller/RoomController.java
+++ b/src/main/java/mafia/mafiatogether/controller/RoomController.java
@@ -24,16 +24,14 @@ public class RoomController {
     private final RoomService roomService;
 
     @PostMapping
-    public ResponseEntity<RoomCreateResponse> create(@RequestBody RoomCreateRequest request) {
+    public ResponseEntity<RoomCreateResponse> create(@RequestBody final RoomCreateRequest request) {
         return ResponseEntity.ok(roomService.create(request));
     }
 
-    //TODO 방장 역할 추가
-    //TODO GET -> POST
     @GetMapping
     public ResponseEntity<Void> join(
-            @RequestParam("code") String code,
-            @RequestParam("name") String name
+            @RequestParam("code") final String code,
+            @RequestParam("name") final String name
     ) {
         roomService.join(code,name);
         return ResponseEntity.ok().build();
@@ -41,7 +39,7 @@ public class RoomController {
 
     @GetMapping("/status")
     public ResponseEntity<RoomStatusResponse> findStatus(
-            @PlayerInfo PlayerInfoDto playerInfoDto
+            @PlayerInfo final PlayerInfoDto playerInfoDto
     ) {
         return ResponseEntity.ok(roomService.findStatus(playerInfoDto.code()));
     }
@@ -49,8 +47,8 @@ public class RoomController {
 
     @PatchMapping("/status")
     public ResponseEntity<Void> modifyStatus(
-            @PlayerInfo PlayerInfoDto playerInfoDto,
-            @RequestBody RoomModifyRequest request
+            @PlayerInfo final PlayerInfoDto playerInfoDto,
+            @RequestBody final RoomModifyRequest request
     ) {
         roomService.modifyStatus(playerInfoDto.code(), request);
         return ResponseEntity.ok().build();

--- a/src/main/java/mafia/mafiatogether/controller/RoomController.java
+++ b/src/main/java/mafia/mafiatogether/controller/RoomController.java
@@ -2,6 +2,7 @@ package mafia.mafiatogether.controller;
 
 import lombok.RequiredArgsConstructor;
 import mafia.mafiatogether.service.RoomService;
+import mafia.mafiatogether.service.dto.PlayerInfoDto;
 import mafia.mafiatogether.service.dto.RoomCreateRequest;
 import mafia.mafiatogether.service.dto.RoomCreateResponse;
 import mafia.mafiatogether.service.dto.RoomStatusResponse;
@@ -10,7 +11,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -27,8 +27,8 @@ public class RoomController {
 
     @GetMapping("/status")
     public ResponseEntity<RoomStatusResponse> findStatus(
-            @RequestParam("code") String code
+            @PlayerInfo PlayerInfoDto playerInfoDto
     ) {
-        return ResponseEntity.ok(roomService.findStatus(code));
+        return ResponseEntity.ok(roomService.findStatus(playerInfoDto.code()));
     }
 }

--- a/src/main/java/mafia/mafiatogether/controller/RoomController.java
+++ b/src/main/java/mafia/mafiatogether/controller/RoomController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,6 +26,17 @@ public class RoomController {
     @PostMapping
     public ResponseEntity<RoomCreateResponse> create(@RequestBody RoomCreateRequest request) {
         return ResponseEntity.ok(roomService.create(request));
+    }
+
+    //TODO 방장 역할 추가
+    //TODO GET -> POST
+    @GetMapping
+    public ResponseEntity<Void> join(
+            @RequestParam("code") String code,
+            @RequestParam("name") String name
+    ) {
+        roomService.join(code,name);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/status")

--- a/src/main/java/mafia/mafiatogether/domain/CodeGenerator.java
+++ b/src/main/java/mafia/mafiatogether/domain/CodeGenerator.java
@@ -1,0 +1,21 @@
+package mafia.mafiatogether.domain;
+
+
+import java.util.Random;
+
+public class CodeGenerator {
+
+    private final static int LEFT_LIMIT = 48;
+    private final static int RIGHT_LIMIT = 122;
+    private final static int TARGET_STRING_LENGTH = 10;
+
+    public static String generate() {
+        Random random = new Random();
+
+        return random.ints(LEFT_LIMIT, RIGHT_LIMIT + 1)
+                .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+                .limit(TARGET_STRING_LENGTH)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+    }
+}

--- a/src/main/java/mafia/mafiatogether/domain/Player.java
+++ b/src/main/java/mafia/mafiatogether/domain/Player.java
@@ -1,9 +1,11 @@
 package mafia.mafiatogether.domain;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
+@EqualsAndHashCode
 @RequiredArgsConstructor
 public class Player {
 

--- a/src/main/java/mafia/mafiatogether/domain/Player.java
+++ b/src/main/java/mafia/mafiatogether/domain/Player.java
@@ -1,9 +1,11 @@
 package mafia.mafiatogether.domain;
 
-public class Player {
-    private final String name;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
-    public Player(String name) {
-        this.name = name;
-    }
+@Getter
+@RequiredArgsConstructor
+public class Player {
+
+    private final String name;
 }

--- a/src/main/java/mafia/mafiatogether/domain/Player.java
+++ b/src/main/java/mafia/mafiatogether/domain/Player.java
@@ -1,0 +1,9 @@
+package mafia.mafiatogether.domain;
+
+public class Player {
+    private final String name;
+
+    public Player(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/mafia/mafiatogether/domain/Room.java
+++ b/src/main/java/mafia/mafiatogether/domain/Room.java
@@ -25,4 +25,8 @@ public class Room {
     public void modifyStatus(final Status status) {
         this.status = status;
     }
+
+    public void joinPlayer(final Player player) {
+        players.add(player);
+    }
 }

--- a/src/main/java/mafia/mafiatogether/domain/Room.java
+++ b/src/main/java/mafia/mafiatogether/domain/Room.java
@@ -3,8 +3,10 @@ package mafia.mafiatogether.domain;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class Room {
 
@@ -18,5 +20,12 @@ public class Room {
                 Status.WAIT,
                 roomInfo
         );
+    }
+
+    public Player findPlayerByName(final String name) {
+        return players.stream()
+                .filter(player -> player.getName().equals(name))
+                .findAny()
+                .orElseThrow();
     }
 }

--- a/src/main/java/mafia/mafiatogether/domain/Room.java
+++ b/src/main/java/mafia/mafiatogether/domain/Room.java
@@ -3,15 +3,15 @@ package mafia.mafiatogether.domain;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Room {
 
     private final List<Player> players;
-    private final Status status;
+    private Status status;
     private final RoomInfo roomInfo;
 
     public static Room create(final RoomInfo roomInfo) {
@@ -22,10 +22,7 @@ public class Room {
         );
     }
 
-    public Player findPlayerByName(final String name) {
-        return players.stream()
-                .filter(player -> player.getName().equals(name))
-                .findAny()
-                .orElseThrow();
+    public void modifyStatus(final Status status) {
+        this.status = status;
     }
 }

--- a/src/main/java/mafia/mafiatogether/domain/Room.java
+++ b/src/main/java/mafia/mafiatogether/domain/Room.java
@@ -1,0 +1,22 @@
+package mafia.mafiatogether.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class Room {
+
+    private final List<Player> players;
+    private final Status status;
+    private final RoomInfo roomInfo;
+
+    public static Room create(final RoomInfo roomInfo) {
+        return new Room(
+                new ArrayList<>(),
+                Status.WAIT,
+                roomInfo
+        );
+    }
+}

--- a/src/main/java/mafia/mafiatogether/domain/RoomInfo.java
+++ b/src/main/java/mafia/mafiatogether/domain/RoomInfo.java
@@ -1,0 +1,14 @@
+package mafia.mafiatogether.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RoomInfo {
+
+    private final int total;
+    private final int mafia;
+    private final int doctor;
+    private final int police;
+}

--- a/src/main/java/mafia/mafiatogether/domain/RoomManager.java
+++ b/src/main/java/mafia/mafiatogether/domain/RoomManager.java
@@ -25,6 +25,9 @@ public class RoomManager {
     }
 
     public Room findByCode(final String code) {
+        if (!rooms.containsKey(code)) {
+            throw new IllegalArgumentException("입장 코드가 올바르지 않습니다. 올바른 코드를 입력해주세요");
+        }
         return rooms.get(code);
     }
 }

--- a/src/main/java/mafia/mafiatogether/domain/RoomManager.java
+++ b/src/main/java/mafia/mafiatogether/domain/RoomManager.java
@@ -23,4 +23,8 @@ public class RoomManager {
         rooms.put(code, Room.create(roomInfo));
         return code;
     }
+
+    public Room findByCode(final String code) {
+        return rooms.get(code);
+    }
 }

--- a/src/main/java/mafia/mafiatogether/domain/RoomManager.java
+++ b/src/main/java/mafia/mafiatogether/domain/RoomManager.java
@@ -1,0 +1,26 @@
+package mafia.mafiatogether.domain;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RoomManager {
+
+    private final Map<String, Room> rooms;
+
+    protected RoomManager() {
+        this.rooms = new HashMap<>();
+    }
+
+    public String create(
+            RoomInfo roomInfo
+    ) {
+        String code = CodeGenerator.generate();
+        while (rooms.containsKey(code)) {
+            code = CodeGenerator.generate();
+        }
+        rooms.put(code, Room.create(roomInfo));
+        return code;
+    }
+}

--- a/src/main/java/mafia/mafiatogether/domain/Status.java
+++ b/src/main/java/mafia/mafiatogether/domain/Status.java
@@ -1,0 +1,10 @@
+package mafia.mafiatogether.domain;
+
+public enum Status {
+
+    WAIT,
+    START,
+    DAY,
+    NIGHT,
+    END
+}

--- a/src/main/java/mafia/mafiatogether/service/RoomService.java
+++ b/src/main/java/mafia/mafiatogether/service/RoomService.java
@@ -1,0 +1,19 @@
+package mafia.mafiatogether.service;
+
+import lombok.RequiredArgsConstructor;
+import mafia.mafiatogether.domain.RoomManager;
+import mafia.mafiatogether.service.dto.CreateRoomRequest;
+import mafia.mafiatogether.service.dto.CreateRoomResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoomService {
+
+    private final RoomManager roomManager;
+
+    public CreateRoomResponse create(final CreateRoomRequest request) {
+        String code = roomManager.create(request.toDomain());
+        return new CreateRoomResponse(code);
+    }
+}

--- a/src/main/java/mafia/mafiatogether/service/RoomService.java
+++ b/src/main/java/mafia/mafiatogether/service/RoomService.java
@@ -1,9 +1,11 @@
 package mafia.mafiatogether.service;
 
 import lombok.RequiredArgsConstructor;
+import mafia.mafiatogether.domain.Room;
 import mafia.mafiatogether.domain.RoomManager;
-import mafia.mafiatogether.service.dto.CreateRoomRequest;
-import mafia.mafiatogether.service.dto.CreateRoomResponse;
+import mafia.mafiatogether.service.dto.RoomCreateRequest;
+import mafia.mafiatogether.service.dto.RoomCreateResponse;
+import mafia.mafiatogether.service.dto.RoomStatusResponse;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,8 +14,13 @@ public class RoomService {
 
     private final RoomManager roomManager;
 
-    public CreateRoomResponse create(final CreateRoomRequest request) {
+    public RoomCreateResponse create(final RoomCreateRequest request) {
         String code = roomManager.create(request.toDomain());
-        return new CreateRoomResponse(code);
+        return new RoomCreateResponse(code);
+    }
+
+    public RoomStatusResponse findStatus(final String code) {
+        Room room = roomManager.findByCode(code);
+        return new RoomStatusResponse(room.getStatus());
     }
 }

--- a/src/main/java/mafia/mafiatogether/service/RoomService.java
+++ b/src/main/java/mafia/mafiatogether/service/RoomService.java
@@ -17,22 +17,22 @@ public class RoomService {
     private final RoomManager roomManager;
 
     public RoomCreateResponse create(final RoomCreateRequest request) {
-        String code = roomManager.create(request.toDomain());
+        final String code = roomManager.create(request.toDomain());
         return new RoomCreateResponse(code);
     }
 
     public void join(final String code, final String name) {
-        Room room = roomManager.findByCode(code);
+        final Room room = roomManager.findByCode(code);
         room.joinPlayer(new Player(name));
     }
 
     public RoomStatusResponse findStatus(final String code) {
-        Room room = roomManager.findByCode(code);
+        final Room room = roomManager.findByCode(code);
         return new RoomStatusResponse(room.getStatus());
     }
 
     public void modifyStatus(final String code, final RoomModifyRequest request) {
-        Room room = roomManager.findByCode(code);
+        final Room room = roomManager.findByCode(code);
         room.modifyStatus(request.status());
     }
 }

--- a/src/main/java/mafia/mafiatogether/service/RoomService.java
+++ b/src/main/java/mafia/mafiatogether/service/RoomService.java
@@ -1,6 +1,7 @@
 package mafia.mafiatogether.service;
 
 import lombok.RequiredArgsConstructor;
+import mafia.mafiatogether.domain.Player;
 import mafia.mafiatogether.domain.Room;
 import mafia.mafiatogether.domain.RoomManager;
 import mafia.mafiatogether.service.dto.RoomCreateRequest;
@@ -18,6 +19,11 @@ public class RoomService {
     public RoomCreateResponse create(final RoomCreateRequest request) {
         String code = roomManager.create(request.toDomain());
         return new RoomCreateResponse(code);
+    }
+
+    public void join(final String code, final String name) {
+        Room room = roomManager.findByCode(code);
+        room.joinPlayer(new Player(name));
     }
 
     public RoomStatusResponse findStatus(final String code) {

--- a/src/main/java/mafia/mafiatogether/service/RoomService.java
+++ b/src/main/java/mafia/mafiatogether/service/RoomService.java
@@ -5,6 +5,7 @@ import mafia.mafiatogether.domain.Room;
 import mafia.mafiatogether.domain.RoomManager;
 import mafia.mafiatogether.service.dto.RoomCreateRequest;
 import mafia.mafiatogether.service.dto.RoomCreateResponse;
+import mafia.mafiatogether.service.dto.RoomModifyRequest;
 import mafia.mafiatogether.service.dto.RoomStatusResponse;
 import org.springframework.stereotype.Service;
 
@@ -22,5 +23,10 @@ public class RoomService {
     public RoomStatusResponse findStatus(final String code) {
         Room room = roomManager.findByCode(code);
         return new RoomStatusResponse(room.getStatus());
+    }
+
+    public void modifyStatus(final String code, final RoomModifyRequest request) {
+        Room room = roomManager.findByCode(code);
+        room.modifyStatus(request.status());
     }
 }

--- a/src/main/java/mafia/mafiatogether/service/dto/CreateRoomRequest.java
+++ b/src/main/java/mafia/mafiatogether/service/dto/CreateRoomRequest.java
@@ -1,0 +1,15 @@
+package mafia.mafiatogether.service.dto;
+
+import mafia.mafiatogether.domain.RoomInfo;
+
+public record CreateRoomRequest(
+        Integer total,
+        Integer mafia,
+        Integer doctor,
+        Integer police
+) {
+
+    public RoomInfo toDomain() {
+        return new RoomInfo(total, mafia, doctor, police);
+    }
+}

--- a/src/main/java/mafia/mafiatogether/service/dto/CreateRoomResponse.java
+++ b/src/main/java/mafia/mafiatogether/service/dto/CreateRoomResponse.java
@@ -1,0 +1,6 @@
+package mafia.mafiatogether.service.dto;
+
+public record CreateRoomResponse(
+        String code
+) {
+}

--- a/src/main/java/mafia/mafiatogether/service/dto/PlayerInfoDto.java
+++ b/src/main/java/mafia/mafiatogether/service/dto/PlayerInfoDto.java
@@ -1,0 +1,7 @@
+package mafia.mafiatogether.service.dto;
+
+public record PlayerInfoDto(
+        String code,
+        String name
+) {
+}

--- a/src/main/java/mafia/mafiatogether/service/dto/RoomCreateRequest.java
+++ b/src/main/java/mafia/mafiatogether/service/dto/RoomCreateRequest.java
@@ -2,7 +2,7 @@ package mafia.mafiatogether.service.dto;
 
 import mafia.mafiatogether.domain.RoomInfo;
 
-public record CreateRoomRequest(
+public record RoomCreateRequest(
         Integer total,
         Integer mafia,
         Integer doctor,

--- a/src/main/java/mafia/mafiatogether/service/dto/RoomCreateResponse.java
+++ b/src/main/java/mafia/mafiatogether/service/dto/RoomCreateResponse.java
@@ -1,6 +1,6 @@
 package mafia.mafiatogether.service.dto;
 
-public record CreateRoomResponse(
+public record RoomCreateResponse(
         String code
 ) {
 }

--- a/src/main/java/mafia/mafiatogether/service/dto/RoomModifyRequest.java
+++ b/src/main/java/mafia/mafiatogether/service/dto/RoomModifyRequest.java
@@ -1,0 +1,8 @@
+package mafia.mafiatogether.service.dto;
+
+import mafia.mafiatogether.domain.Status;
+
+public record RoomModifyRequest(
+        Status status
+) {
+}

--- a/src/main/java/mafia/mafiatogether/service/dto/RoomStatusResponse.java
+++ b/src/main/java/mafia/mafiatogether/service/dto/RoomStatusResponse.java
@@ -1,0 +1,9 @@
+package mafia.mafiatogether.service.dto;
+
+import mafia.mafiatogether.domain.Status;
+
+public record RoomStatusResponse(
+        Status status
+
+) {
+}

--- a/src/test/java/mafia/mafiatogether/controller/RoomControllerTest.java
+++ b/src/test/java/mafia/mafiatogether/controller/RoomControllerTest.java
@@ -2,11 +2,16 @@ package mafia.mafiatogether.controller;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import mafia.mafiatogether.domain.RoomInfo;
+import mafia.mafiatogether.domain.RoomManager;
+import mafia.mafiatogether.domain.Status;
 import mafia.mafiatogether.service.dto.RoomCreateRequest;
 import mafia.mafiatogether.service.dto.RoomCreateResponse;
+import mafia.mafiatogether.service.dto.RoomStatusResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -15,6 +20,9 @@ import org.springframework.http.HttpStatus;
 @SuppressWarnings("NonAsciiCharacters")
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class RoomControllerTest {
+
+    @Autowired
+    private RoomManager roomManager;
 
     @LocalServerPort
     private int port;
@@ -42,5 +50,23 @@ class RoomControllerTest {
 
         //then
         Assertions.assertThat(response.code()).isNotBlank();
+    }
+
+    @Test
+    void 방을_상태를_확인할_수_있다() {
+        //given
+        String code = roomManager.create(new RoomInfo(5, 1, 1, 1));
+
+        //when
+        RoomStatusResponse response = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .when().get("/room/status?code=" + code)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(RoomStatusResponse.class);
+
+        //then
+        Assertions.assertThat(response.status()).isEqualTo(Status.WAIT);
     }
 }

--- a/src/test/java/mafia/mafiatogether/controller/RoomControllerTest.java
+++ b/src/test/java/mafia/mafiatogether/controller/RoomControllerTest.java
@@ -1,0 +1,46 @@
+package mafia.mafiatogether.controller;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import mafia.mafiatogether.service.dto.CreateRoomRequest;
+import mafia.mafiatogether.service.dto.CreateRoomResponse;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+
+@SuppressWarnings("NonAsciiCharacters")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class RoomControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+
+    @Test
+    void 방을_생성할_수_있다() {
+        //given
+        CreateRoomRequest request = new CreateRoomRequest(5, 1, 1, 1);
+
+        //when
+        CreateRoomResponse response = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when().post("/room")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(CreateRoomResponse.class);
+
+        //then
+        Assertions.assertThat(response.code()).isNotBlank();
+    }
+}

--- a/src/test/java/mafia/mafiatogether/controller/RoomControllerTest.java
+++ b/src/test/java/mafia/mafiatogether/controller/RoomControllerTest.java
@@ -3,6 +3,7 @@ package mafia.mafiatogether.controller;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import java.util.Base64;
+import mafia.mafiatogether.domain.Player;
 import mafia.mafiatogether.domain.Room;
 import mafia.mafiatogether.domain.RoomInfo;
 import mafia.mafiatogether.domain.RoomManager;
@@ -94,5 +95,22 @@ class RoomControllerTest {
         //then
         Room room = roomManager.findByCode(code);
         Assertions.assertThat(room.getStatus()).isEqualTo(Status.START);
+    }
+
+    @Test
+    void 방에_참가할_수_있다() {
+        //given
+        String code = roomManager.create(new RoomInfo(5, 1, 1, 1));
+
+        //when
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .when().get("/room?code=" + code + "&name=power")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+
+        //then
+        Room room = roomManager.findByCode(code);
+        Assertions.assertThat(room.getPlayers()).contains(new Player("power"));
     }
 }

--- a/src/test/java/mafia/mafiatogether/controller/RoomControllerTest.java
+++ b/src/test/java/mafia/mafiatogether/controller/RoomControllerTest.java
@@ -2,8 +2,8 @@ package mafia.mafiatogether.controller;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import mafia.mafiatogether.service.dto.CreateRoomRequest;
-import mafia.mafiatogether.service.dto.CreateRoomResponse;
+import mafia.mafiatogether.service.dto.RoomCreateRequest;
+import mafia.mafiatogether.service.dto.RoomCreateResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,17 +28,17 @@ class RoomControllerTest {
     @Test
     void 방을_생성할_수_있다() {
         //given
-        CreateRoomRequest request = new CreateRoomRequest(5, 1, 1, 1);
+        RoomCreateRequest request = new RoomCreateRequest(5, 1, 1, 1);
 
         //when
-        CreateRoomResponse response = RestAssured.given().log().all()
+        RoomCreateResponse response = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(request)
                 .when().post("/room")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract()
-                .as(CreateRoomResponse.class);
+                .as(RoomCreateResponse.class);
 
         //then
         Assertions.assertThat(response.code()).isNotBlank();

--- a/src/test/java/mafia/mafiatogether/controller/RoomControllerTest.java
+++ b/src/test/java/mafia/mafiatogether/controller/RoomControllerTest.java
@@ -3,11 +3,13 @@ package mafia.mafiatogether.controller;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import java.util.Base64;
+import mafia.mafiatogether.domain.Room;
 import mafia.mafiatogether.domain.RoomInfo;
 import mafia.mafiatogether.domain.RoomManager;
 import mafia.mafiatogether.domain.Status;
 import mafia.mafiatogether.service.dto.RoomCreateRequest;
 import mafia.mafiatogether.service.dto.RoomCreateResponse;
+import mafia.mafiatogether.service.dto.RoomModifyRequest;
 import mafia.mafiatogether.service.dto.RoomStatusResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,5 +73,26 @@ class RoomControllerTest {
 
         //then
         Assertions.assertThat(response.status()).isEqualTo(Status.WAIT);
+    }
+
+    @Test
+    void 방을_상태를_변경할_수_있다() {
+        //given
+        String code = roomManager.create(new RoomInfo(5, 1, 1, 1));
+        String basic = Base64.getEncoder().encodeToString((code + ":" + "power").getBytes());
+        RoomModifyRequest request = new RoomModifyRequest(Status.START);
+
+        //when
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .header("Authorization", "Basic " + basic)
+                .when().patch("/room/status")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+
+        //then
+        Room room = roomManager.findByCode(code);
+        Assertions.assertThat(room.getStatus()).isEqualTo(Status.START);
     }
 }

--- a/src/test/java/mafia/mafiatogether/controller/RoomControllerTest.java
+++ b/src/test/java/mafia/mafiatogether/controller/RoomControllerTest.java
@@ -2,6 +2,7 @@ package mafia.mafiatogether.controller;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import java.util.Base64;
 import mafia.mafiatogether.domain.RoomInfo;
 import mafia.mafiatogether.domain.RoomManager;
 import mafia.mafiatogether.domain.Status;
@@ -56,11 +57,13 @@ class RoomControllerTest {
     void 방을_상태를_확인할_수_있다() {
         //given
         String code = roomManager.create(new RoomInfo(5, 1, 1, 1));
+        String basic = Base64.getEncoder().encodeToString((code + ":" + "power").getBytes());
 
         //when
         RoomStatusResponse response = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .when().get("/room/status?code=" + code)
+                .header("Authorization", "Basic " + basic)
+                .when().get("/room/status")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract()

--- a/src/test/java/mafia/mafiatogether/domain/CodeGeneratorTest.java
+++ b/src/test/java/mafia/mafiatogether/domain/CodeGeneratorTest.java
@@ -1,0 +1,15 @@
+package mafia.mafiatogether.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+class CodeGeneratorTest {
+
+    @Test
+    void 랜덤_코드를_생성할_수_있다() {
+        String code = CodeGenerator.generate();
+
+        Assertions.assertThat(code).hasSize(10);
+    }
+}

--- a/src/test/java/mafia/mafiatogether/domain/RoomManagerTest.java
+++ b/src/test/java/mafia/mafiatogether/domain/RoomManagerTest.java
@@ -1,0 +1,17 @@
+package mafia.mafiatogether.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class RoomManagerTest {
+
+    @Test
+    void 중복되지_않은_방을_생성할_수_있다() {
+        RoomManager roomManager = new RoomManager();
+        RoomInfo roomInfo = new RoomInfo(5, 1, 1, 1);
+        String roomA = roomManager.create(roomInfo);
+        String roomB = roomManager.create(roomInfo);
+
+        Assertions.assertThat(roomA).isNotEqualTo(roomB);
+    }
+}


### PR DESCRIPTION
- 인증은 MVP이기 때문에 임시로 [Basic](https://docs.tosspayments.com/resources/glossary/basic-auth) 인증 방식 사용
- 사용자가 참가할때 단순 조회가아니라 리소스가 변경되기때문에 POST가 어울릴꺼같음
- 방을 생성할때 방장의 정보와 함께 만들면 좋을것같음
