### PR TITLE
feat 채팅 조회/전송 기능 구현

### DIFF
--- a/src/main/java/mafia/mafiatogether/controller/ChatController.java
+++ b/src/main/java/mafia/mafiatogether/controller/ChatController.java
@@ -22,12 +22,12 @@ public class ChatController {
     private final ChatService chatService;
 
     @GetMapping
-    public ResponseEntity<List<ChatResponse>> getChat(@PlayerInfo PlayerInfoDto playerInfoDto) {
-        return ResponseEntity.ok(chatService.getChat(playerInfoDto.code(), playerInfoDto.name()));
+    public ResponseEntity<List<ChatResponse>> findAllChat(@PlayerInfo PlayerInfoDto playerInfoDto) {
+        return ResponseEntity.ok(chatService.findAllChat(playerInfoDto.code(), playerInfoDto.name()));
     }
 
     @PostMapping
-    public ResponseEntity<Void> sendChat(
+    public ResponseEntity<Void> createChat(
             @PlayerInfo PlayerInfoDto playerInfoDto,
             @RequestBody ChatRequest request
     ) {

--- a/src/main/java/mafia/mafiatogether/controller/ChatController.java
+++ b/src/main/java/mafia/mafiatogether/controller/ChatController.java
@@ -27,11 +27,11 @@ public class ChatController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> createChat(
+    public ResponseEntity<Void> saveChat(
             @PlayerInfo PlayerInfoDto playerInfoDto,
             @RequestBody ChatRequest request
     ) {
-        chatService.createChat(playerInfoDto.code(), playerInfoDto.name(), request);
+        chatService.saveChat(playerInfoDto.code(), playerInfoDto.name(), request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/mafia/mafiatogether/controller/ChatController.java
+++ b/src/main/java/mafia/mafiatogether/controller/ChatController.java
@@ -3,10 +3,14 @@ package mafia.mafiatogether.controller;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import mafia.mafiatogether.service.ChatService;
+import mafia.mafiatogether.service.dto.ChatRequest;
 import mafia.mafiatogether.service.dto.ChatResponse;
 import mafia.mafiatogether.service.dto.PlayerInfoDto;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,5 +24,14 @@ public class ChatController {
     @GetMapping
     public ResponseEntity<List<ChatResponse>> getChat(@PlayerInfo PlayerInfoDto playerInfoDto) {
         return ResponseEntity.ok(chatService.getChat(playerInfoDto.code(), playerInfoDto.name()));
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> sendChat(
+            @PlayerInfo PlayerInfoDto playerInfoDto,
+            @RequestBody ChatRequest request
+    ) {
+        chatService.createChat(playerInfoDto.code(), playerInfoDto.name(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/mafia/mafiatogether/controller/ChatController.java
+++ b/src/main/java/mafia/mafiatogether/controller/ChatController.java
@@ -1,0 +1,24 @@
+package mafia.mafiatogether.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import mafia.mafiatogether.service.ChatService;
+import mafia.mafiatogether.service.dto.ChatResponse;
+import mafia.mafiatogether.service.dto.PlayerInfoDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/chat")
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @GetMapping
+    public ResponseEntity<List<ChatResponse>> getChat(@PlayerInfo PlayerInfoDto playerInfoDto) {
+        return ResponseEntity.ok(chatService.getChat(playerInfoDto.code(), playerInfoDto.name()));
+    }
+}

--- a/src/main/java/mafia/mafiatogether/domain/Chat.java
+++ b/src/main/java/mafia/mafiatogether/domain/Chat.java
@@ -15,4 +15,8 @@ public class Chat {
     public static Chat chat() {
         return new Chat(new ArrayList<>());
     }
+
+    public void save(final Message message){
+        messages.add(message);
+    }
 }

--- a/src/main/java/mafia/mafiatogether/domain/Chat.java
+++ b/src/main/java/mafia/mafiatogether/domain/Chat.java
@@ -6,8 +6,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class Chat {
 
     private final List<Message> messages;
@@ -16,7 +16,7 @@ public class Chat {
         return new Chat(new ArrayList<>());
     }
 
-    public void save(final Message message){
+    public void save(final Message message) {
         messages.add(message);
     }
 }

--- a/src/main/java/mafia/mafiatogether/domain/Chat.java
+++ b/src/main/java/mafia/mafiatogether/domain/Chat.java
@@ -1,0 +1,18 @@
+package mafia.mafiatogether.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class Chat {
+
+    private final List<Message> messages;
+
+    public static Chat chat() {
+        return new Chat(new ArrayList<>());
+    }
+}

--- a/src/main/java/mafia/mafiatogether/domain/Message.java
+++ b/src/main/java/mafia/mafiatogether/domain/Message.java
@@ -1,6 +1,7 @@
 package mafia.mafiatogether.domain;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,6 +12,10 @@ public class Message {
     private final Player player;
     private final String contents;
     private final Timestamp timestamp;
+
+    public static Message of(final Player player, final String contents){
+        return new Message(player,contents,Timestamp.valueOf(LocalDateTime.now()));
+    }
 
     public String getName(){
         return player.getName();

--- a/src/main/java/mafia/mafiatogether/domain/Message.java
+++ b/src/main/java/mafia/mafiatogether/domain/Message.java
@@ -5,23 +5,23 @@ import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 @Getter
+@RequiredArgsConstructor
 public class Message {
 
     private final Player player;
     private final String contents;
     private final Timestamp timestamp;
 
-    public static Message of(final Player player, final String contents){
-        return new Message(player,contents,Timestamp.valueOf(LocalDateTime.now()));
+    public static Message of(final Player player, final String contents) {
+        return new Message(player, contents, Timestamp.valueOf(LocalDateTime.now()));
     }
 
-    public String getName(){
+    public String getName() {
         return player.getName();
     }
 
-    public boolean isOwner(final String name){
+    public boolean isOwner(final String name) {
         return player.getName().equals(name);
     }
 }

--- a/src/main/java/mafia/mafiatogether/domain/Message.java
+++ b/src/main/java/mafia/mafiatogether/domain/Message.java
@@ -1,0 +1,22 @@
+package mafia.mafiatogether.domain;
+
+import java.sql.Timestamp;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class Message {
+
+    private final Player player;
+    private final String contents;
+    private final Timestamp timestamp;
+
+    public String getName(){
+        return player.getName();
+    }
+
+    public boolean isOwner(final String name){
+        return player.getName().equals(name);
+    }
+}

--- a/src/main/java/mafia/mafiatogether/domain/Room.java
+++ b/src/main/java/mafia/mafiatogether/domain/Room.java
@@ -13,12 +13,14 @@ public class Room {
     private final List<Player> players;
     private Status status;
     private final RoomInfo roomInfo;
+    private final Chat chat;
 
     public static Room create(final RoomInfo roomInfo) {
         return new Room(
                 new ArrayList<>(),
                 Status.WAIT,
-                roomInfo
+                roomInfo,
+                Chat.chat()
         );
     }
 

--- a/src/main/java/mafia/mafiatogether/domain/Room.java
+++ b/src/main/java/mafia/mafiatogether/domain/Room.java
@@ -1,7 +1,7 @@
 package mafia.mafiatogether.domain;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,14 +10,14 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Room {
 
-    private final List<Player> players;
+    private final Map<String, Player> players;
     private Status status;
     private final RoomInfo roomInfo;
     private final Chat chat;
 
     public static Room create(final RoomInfo roomInfo) {
         return new Room(
-                new ArrayList<>(),
+                new HashMap<>(),
                 Status.WAIT,
                 roomInfo,
                 Chat.chat()
@@ -29,6 +29,13 @@ public class Room {
     }
 
     public void joinPlayer(final Player player) {
-        players.add(player);
+        players.put(player.getName(), player);
+    }
+
+    public Player findPlayer(final String name) {
+        if (!players.containsKey(name)) {
+            throw new IllegalArgumentException("존재하지 않는 플레이어입니다.");
+        }
+        return players.get(name);
     }
 }

--- a/src/main/java/mafia/mafiatogether/domain/Room.java
+++ b/src/main/java/mafia/mafiatogether/domain/Room.java
@@ -1,7 +1,7 @@
 package mafia.mafiatogether.domain;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,7 +17,7 @@ public class Room {
 
     public static Room create(final RoomInfo roomInfo) {
         return new Room(
-                new HashMap<>(),
+                new ConcurrentHashMap<>(),
                 Status.WAIT,
                 roomInfo,
                 Chat.chat()

--- a/src/main/java/mafia/mafiatogether/service/ChatService.java
+++ b/src/main/java/mafia/mafiatogether/service/ChatService.java
@@ -21,11 +21,11 @@ public class ChatService {
         final Room room = roomManager.findByCode(code);
         final Chat chat = room.getChat();
         return chat.getMessages().stream()
-                .map(message -> ChatResponse.byOfName(message, name))
+                .map(message -> ChatResponse.of(message, name))
                 .toList();
     }
 
-    public void createChat(final String code, final String name, final ChatRequest chatRequest) {
+    public void saveChat(final String code, final String name, final ChatRequest chatRequest) {
         final Room room = roomManager.findByCode(code);
         final Chat chat = room.getChat();
         final Player player = room.findPlayer(name);

--- a/src/main/java/mafia/mafiatogether/service/ChatService.java
+++ b/src/main/java/mafia/mafiatogether/service/ChatService.java
@@ -1,0 +1,30 @@
+package mafia.mafiatogether.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import mafia.mafiatogether.domain.Chat;
+import mafia.mafiatogether.domain.Room;
+import mafia.mafiatogether.domain.RoomManager;
+import mafia.mafiatogether.service.dto.ChatResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final RoomManager roomManager;
+
+    public List<ChatResponse> getChat(final String code, final String name) {
+        final Room room = roomManager.findByCode(code);
+        final Chat chat = room.getChat();
+        return chat.getMessages().stream()
+                .map(message ->
+                        new ChatResponse(
+                                message.getName(),
+                                message.getContents(),
+                                message.getTimestamp(),
+                                message.isOwner(name)
+                        )
+                ).toList();
+    }
+}

--- a/src/main/java/mafia/mafiatogether/service/ChatService.java
+++ b/src/main/java/mafia/mafiatogether/service/ChatService.java
@@ -3,8 +3,11 @@ package mafia.mafiatogether.service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import mafia.mafiatogether.domain.Chat;
+import mafia.mafiatogether.domain.Message;
+import mafia.mafiatogether.domain.Player;
 import mafia.mafiatogether.domain.Room;
 import mafia.mafiatogether.domain.RoomManager;
+import mafia.mafiatogether.service.dto.ChatRequest;
 import mafia.mafiatogether.service.dto.ChatResponse;
 import org.springframework.stereotype.Service;
 
@@ -26,5 +29,12 @@ public class ChatService {
                                 message.isOwner(name)
                         )
                 ).toList();
+    }
+
+    public void createChat(final String code, final String name, final ChatRequest chatRequest){
+        final Room room = roomManager.findByCode(code);
+        final Chat chat = room.getChat();
+        final Player player = room.findPlayer(name);
+        chat.save(Message.of(player,chatRequest.contents()));
     }
 }

--- a/src/main/java/mafia/mafiatogether/service/ChatService.java
+++ b/src/main/java/mafia/mafiatogether/service/ChatService.java
@@ -21,20 +21,14 @@ public class ChatService {
         final Room room = roomManager.findByCode(code);
         final Chat chat = room.getChat();
         return chat.getMessages().stream()
-                .map(message ->
-                        new ChatResponse(
-                                message.getName(),
-                                message.getContents(),
-                                message.getTimestamp(),
-                                message.isOwner(name)
-                        )
-                ).toList();
+                .map(message -> ChatResponse.byOfName(message, name))
+                .toList();
     }
 
-    public void createChat(final String code, final String name, final ChatRequest chatRequest){
+    public void createChat(final String code, final String name, final ChatRequest chatRequest) {
         final Room room = roomManager.findByCode(code);
         final Chat chat = room.getChat();
         final Player player = room.findPlayer(name);
-        chat.save(Message.of(player,chatRequest.contents()));
+        chat.save(Message.of(player, chatRequest.contents()));
     }
 }

--- a/src/main/java/mafia/mafiatogether/service/ChatService.java
+++ b/src/main/java/mafia/mafiatogether/service/ChatService.java
@@ -17,7 +17,7 @@ public class ChatService {
 
     private final RoomManager roomManager;
 
-    public List<ChatResponse> getChat(final String code, final String name) {
+    public List<ChatResponse> findAllChat(final String code, final String name) {
         final Room room = roomManager.findByCode(code);
         final Chat chat = room.getChat();
         return chat.getMessages().stream()

--- a/src/main/java/mafia/mafiatogether/service/dto/ChatRequest.java
+++ b/src/main/java/mafia/mafiatogether/service/dto/ChatRequest.java
@@ -1,0 +1,6 @@
+package mafia.mafiatogether.service.dto;
+
+public record ChatRequest(
+        String contents
+) {
+}

--- a/src/main/java/mafia/mafiatogether/service/dto/ChatResponse.java
+++ b/src/main/java/mafia/mafiatogether/service/dto/ChatResponse.java
@@ -1,0 +1,13 @@
+package mafia.mafiatogether.service.dto;
+
+import java.sql.Timestamp;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ChatResponse {
+
+    private final String name;
+    private final String contents;
+    private final Timestamp timestamp;
+    private final boolean owner;
+}

--- a/src/main/java/mafia/mafiatogether/service/dto/ChatResponse.java
+++ b/src/main/java/mafia/mafiatogether/service/dto/ChatResponse.java
@@ -1,15 +1,23 @@
 package mafia.mafiatogether.service.dto;
 
 import java.sql.Timestamp;
-import lombok.Getter;
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import mafia.mafiatogether.domain.Message;
 
-@RequiredArgsConstructor
-@Getter
-public class ChatResponse {
-
-    private final String name;
-    private final String contents;
-    private final Timestamp timestamp;
-    private final boolean owner;
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public record ChatResponse(
+        String name,
+        String contents,
+        Timestamp timestamp,
+        boolean owner
+) {
+    public static ChatResponse byOfName(final Message message, final String name) {
+        return new ChatResponse(
+                message.getName(),
+                message.getContents(),
+                message.getTimestamp(),
+                message.isOwner(name)
+        );
+    }
 }

--- a/src/main/java/mafia/mafiatogether/service/dto/ChatResponse.java
+++ b/src/main/java/mafia/mafiatogether/service/dto/ChatResponse.java
@@ -1,9 +1,11 @@
 package mafia.mafiatogether.service.dto;
 
 import java.sql.Timestamp;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Getter
 public class ChatResponse {
 
     private final String name;

--- a/src/main/java/mafia/mafiatogether/service/dto/ChatResponse.java
+++ b/src/main/java/mafia/mafiatogether/service/dto/ChatResponse.java
@@ -10,7 +10,7 @@ public record ChatResponse(
         boolean owner
 ) {
 
-    public static ChatResponse byOfName(final Message message, final String name) {
+    public static ChatResponse of(final Message message, final String name) {
         return new ChatResponse(
                 message.getName(),
                 message.getContents(),

--- a/src/main/java/mafia/mafiatogether/service/dto/ChatResponse.java
+++ b/src/main/java/mafia/mafiatogether/service/dto/ChatResponse.java
@@ -1,11 +1,8 @@
 package mafia.mafiatogether.service.dto;
 
 import java.sql.Timestamp;
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
 import mafia.mafiatogether.domain.Message;
 
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public record ChatResponse(
         String name,
         String contents,

--- a/src/main/java/mafia/mafiatogether/service/dto/ChatResponse.java
+++ b/src/main/java/mafia/mafiatogether/service/dto/ChatResponse.java
@@ -9,6 +9,7 @@ public record ChatResponse(
         Timestamp timestamp,
         boolean owner
 ) {
+
     public static ChatResponse byOfName(final Message message, final String name) {
         return new ChatResponse(
                 message.getName(),

--- a/src/test/java/mafia/mafiatogether/controller/ChatControllerTest.java
+++ b/src/test/java/mafia/mafiatogether/controller/ChatControllerTest.java
@@ -1,21 +1,26 @@
 package mafia.mafiatogether.controller;
 
-import static org.hamcrest.Matchers.hasSize;
-
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import mafia.mafiatogether.domain.Message;
 import mafia.mafiatogether.domain.Player;
 import mafia.mafiatogether.domain.Room;
 import mafia.mafiatogether.domain.RoomInfo;
 import mafia.mafiatogether.domain.RoomManager;
+import mafia.mafiatogether.service.dto.ChatResponse;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
@@ -29,9 +34,10 @@ public class ChatControllerTest {
     @Autowired
     private RoomManager roomManager;
 
-    private String code;
+    private static String code;
     private Room room;
-    private Player player;
+    private Player player1;
+    private Player player2;
 
     @LocalServerPort
     private int port;
@@ -45,26 +51,38 @@ public class ChatControllerTest {
     void setRoom() {
         code = roomManager.create(new RoomInfo(5, 1, 1, 1));
         room = roomManager.findByCode(code);
-        player = new Player("power");
-        room.joinPlayer(player);
+        player1 = new Player("power");
+        player2 = new Player("metthew");
+        room.joinPlayer(player1);
+        room.joinPlayer(player2);
     }
 
     @Test
     void 채팅_내역을_조회할_수_있다() {
         // given
         final String basic = Base64.getEncoder().encodeToString((code + ":" + "power").getBytes());
-        room.getChat().save(new Message(player, "contents1", Timestamp.valueOf(LocalDateTime.now())));
-        room.getChat().save(new Message(player, "contents2", Timestamp.valueOf(LocalDateTime.now())));
+        room.getChat().save(new Message(player1, "contents1", Timestamp.valueOf(LocalDateTime.now())));
+        room.getChat().save(new Message(player2, "contents2", Timestamp.valueOf(LocalDateTime.now())));
 
-        // when
-        RestAssured.given().log().all()
+        // when & then
+        List<ChatResponse> responses = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .header("Authorization", "Basic " + basic)
                 .when().get("/chat")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
-                .body("contents", hasSize(2));
+                .extract()
+                .body()
+                .jsonPath().getList(".", ChatResponse.class);
 
+        SoftAssertions.assertSoftly(
+                softAssertions -> {
+                    softAssertions.assertThat(responses.get(0).name()).isEqualTo(player1.getName());
+                    softAssertions.assertThat(responses.get(0).contents()).isEqualTo("contents1");
+                    softAssertions.assertThat(responses.get(1).name()).isEqualTo(player2.getName());
+                    softAssertions.assertThat(responses.get(1).contents()).isEqualTo("contents2");
+                }
+        );
     }
 
     @Test
@@ -84,5 +102,32 @@ public class ChatControllerTest {
         // then
         Assertions.assertThat(room.getChat().getMessages().stream().map(Message::getContents))
                 .contains("contents");
+    }
+
+    @ParameterizedTest(name = "{0} 채팅 전송에 실패한다.")
+    @MethodSource("failCaseProvider")
+    void 채팅_전송에_실패한다(
+            final String testCase,
+            final String code,
+            final String name
+    ) {
+        // given
+        final String basic = Base64.getEncoder().encodeToString((code + ":" + name).getBytes());
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Basic " + basic)
+                .body(Map.of("contents", "contents"))
+                .when().post("/chat")
+                .then().log().all()
+                .statusCode(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    }
+
+    static Stream<Arguments> failCaseProvider() {
+        return Stream.of(
+                Arguments.of("방에 존재하지 않는 유저의 경우", code, "dali"),
+                Arguments.of("존재하지 않는 방의 경우", "testCode", "metthew")
+        );
     }
 }

--- a/src/test/java/mafia/mafiatogether/controller/ChatControllerTest.java
+++ b/src/test/java/mafia/mafiatogether/controller/ChatControllerTest.java
@@ -1,0 +1,54 @@
+package mafia.mafiatogether.controller;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.util.Base64;
+import mafia.mafiatogether.domain.Room;
+import mafia.mafiatogether.domain.RoomInfo;
+import mafia.mafiatogether.domain.RoomManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+
+@SuppressWarnings("NonAsciiCharacters")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class ChatControllerTest {
+
+    @Autowired
+    private RoomManager roomManager;
+
+    private String code;
+    private Room room;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @BeforeEach
+    void setRoom() {
+        code = roomManager.create(new RoomInfo(5, 1, 1, 1));
+        room = roomManager.findByCode(code);
+    }
+
+    @Test
+    void 채팅_내역을_조회할_수_있다() {
+        // given
+        final String basic = Base64.getEncoder().encodeToString((code + ":" + "power").getBytes());
+
+        // when
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Basic " + basic)
+                .when().get("/chat")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+    }
+}

--- a/src/test/java/mafia/mafiatogether/controller/RoomControllerTest.java
+++ b/src/test/java/mafia/mafiatogether/controller/RoomControllerTest.java
@@ -3,7 +3,6 @@ package mafia.mafiatogether.controller;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import java.util.Base64;
-import mafia.mafiatogether.domain.Player;
 import mafia.mafiatogether.domain.Room;
 import mafia.mafiatogether.domain.RoomInfo;
 import mafia.mafiatogether.domain.RoomManager;
@@ -111,6 +110,6 @@ class RoomControllerTest {
 
         //then
         Room room = roomManager.findByCode(code);
-        Assertions.assertThat(room.getPlayers()).contains(new Player("power"));
+        Assertions.assertThat(room.getPlayers()).containsKey("power");
     }
 }


### PR DESCRIPTION
#7 채팅 기능 구현

- Chat : 전체 잡담 내용 (List로 Message를 가지고 있음)
- Message : 메세지 하나

추가
- Room의 players를 List<Player> -> Map<String, Player>로 변경
    - chat저장시 player를 찾아야하는데 List일 경우 stream().filter()로 찾아야함 -> 이것보다 Map일 경우 코드도 간결해지고 (어차피 인원 수가 많지는 않을거라 상관없겠지만) 시간복잡도도 낮아짐
    - 추후 이름으로 Player를 찾아야할 경우가 많아질거라 예상 (ex) 투표 지목 대상의 상태(alive) 변경)
    - 꼭 이걸로 하자는 의견은 아님 (저번에도 상황오면 보고 하자고 했던거 같아서 근데 이번에 Player를 찾아야할 경우가 생겨서 일단 넣어봄)