### PR TITLE
방 코드 반환 로직 구현

### DIFF
--- a/src/main/java/mafia/mafiatogether/config/WebMvcConfig.java
+++ b/src/main/java/mafia/mafiatogether/config/WebMvcConfig.java
@@ -3,7 +3,9 @@ package mafia.mafiatogether.config;
 import java.util.List;
 import mafia.mafiatogether.controller.PlayerArgumentResolver;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -12,5 +14,15 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new PlayerArgumentResolver());
+    }
+
+    @Override
+    public void addCorsMappings(final CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                .allowCredentials(true)
+                .exposedHeaders(HttpHeaders.LOCATION);
+        WebMvcConfigurer.super.addCorsMappings(registry);
     }
 }

--- a/src/main/java/mafia/mafiatogether/controller/RoomController.java
+++ b/src/main/java/mafia/mafiatogether/controller/RoomController.java
@@ -3,8 +3,8 @@ package mafia.mafiatogether.controller;
 import lombok.RequiredArgsConstructor;
 import mafia.mafiatogether.service.RoomService;
 import mafia.mafiatogether.service.dto.PlayerInfoDto;
+import mafia.mafiatogether.service.dto.RoomCodeResponse;
 import mafia.mafiatogether.service.dto.RoomCreateRequest;
-import mafia.mafiatogether.service.dto.RoomCreateResponse;
 import mafia.mafiatogether.service.dto.RoomModifyRequest;
 import mafia.mafiatogether.service.dto.RoomStatusResponse;
 import org.springframework.http.ResponseEntity;
@@ -18,13 +18,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/room")
+@RequestMapping("/rooms")
 public class RoomController {
 
     private final RoomService roomService;
 
     @PostMapping
-    public ResponseEntity<RoomCreateResponse> create(@RequestBody final RoomCreateRequest request) {
+    public ResponseEntity<RoomCodeResponse> create(@RequestBody final RoomCreateRequest request) {
         return ResponseEntity.ok(roomService.create(request));
     }
 
@@ -33,7 +33,7 @@ public class RoomController {
             @RequestParam("code") final String code,
             @RequestParam("name") final String name
     ) {
-        roomService.join(code,name);
+        roomService.join(code, name);
         return ResponseEntity.ok().build();
     }
 
@@ -52,5 +52,12 @@ public class RoomController {
     ) {
         roomService.modifyStatus(playerInfoDto.code(), request);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/code")
+    public ResponseEntity<RoomCodeResponse> findCode(
+            @PlayerInfo PlayerInfoDto playerInfoDto
+    ) {
+        return ResponseEntity.ok(new RoomCodeResponse(playerInfoDto.code()));
     }
 }

--- a/src/main/java/mafia/mafiatogether/service/RoomService.java
+++ b/src/main/java/mafia/mafiatogether/service/RoomService.java
@@ -4,8 +4,8 @@ import lombok.RequiredArgsConstructor;
 import mafia.mafiatogether.domain.Player;
 import mafia.mafiatogether.domain.Room;
 import mafia.mafiatogether.domain.RoomManager;
+import mafia.mafiatogether.service.dto.RoomCodeResponse;
 import mafia.mafiatogether.service.dto.RoomCreateRequest;
-import mafia.mafiatogether.service.dto.RoomCreateResponse;
 import mafia.mafiatogether.service.dto.RoomModifyRequest;
 import mafia.mafiatogether.service.dto.RoomStatusResponse;
 import org.springframework.stereotype.Service;
@@ -16,9 +16,9 @@ public class RoomService {
 
     private final RoomManager roomManager;
 
-    public RoomCreateResponse create(final RoomCreateRequest request) {
+    public RoomCodeResponse create(final RoomCreateRequest request) {
         final String code = roomManager.create(request.toDomain());
-        return new RoomCreateResponse(code);
+        return new RoomCodeResponse(code);
     }
 
     public void join(final String code, final String name) {

--- a/src/main/java/mafia/mafiatogether/service/dto/RoomCodeResponse.java
+++ b/src/main/java/mafia/mafiatogether/service/dto/RoomCodeResponse.java
@@ -1,6 +1,6 @@
 package mafia.mafiatogether.service.dto;
 
-public record RoomCreateResponse(
+public record RoomCodeResponse(
         String code
 ) {
 }

--- a/src/test/java/mafia/mafiatogether/controller/RoomControllerTest.java
+++ b/src/test/java/mafia/mafiatogether/controller/RoomControllerTest.java
@@ -40,10 +40,10 @@ class RoomControllerTest {
     @Test
     void 방을_생성할_수_있다() {
         //given
-        RoomCreateRequest request = new RoomCreateRequest(5, 1, 1, 1);
+        final RoomCreateRequest request = new RoomCreateRequest(5, 1, 1, 1);
 
         //when
-        RoomCodeResponse response = RestAssured.given().log().all()
+        final RoomCodeResponse response = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(request)
                 .when().post("/rooms")
@@ -59,11 +59,11 @@ class RoomControllerTest {
     @Test
     void 방을_상태를_확인할_수_있다() {
         //given
-        String code = roomManager.create(new RoomInfo(5, 1, 1, 1));
-        String basic = Base64.getEncoder().encodeToString((code + ":" + "power").getBytes());
+        final String code = roomManager.create(new RoomInfo(5, 1, 1, 1));
+        final String basic = Base64.getEncoder().encodeToString((code + ":" + "power").getBytes());
 
         //when
-        RoomStatusResponse response = RestAssured.given().log().all()
+        final RoomStatusResponse response = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .header("Authorization", "Basic " + basic)
                 .when().get("/rooms/status")
@@ -79,9 +79,9 @@ class RoomControllerTest {
     @Test
     void 방을_상태를_변경할_수_있다() {
         //given
-        String code = roomManager.create(new RoomInfo(5, 1, 1, 1));
-        String basic = Base64.getEncoder().encodeToString((code + ":" + "power").getBytes());
-        RoomModifyRequest request = new RoomModifyRequest(Status.START);
+        final String code = roomManager.create(new RoomInfo(5, 1, 1, 1));
+        final String basic = Base64.getEncoder().encodeToString((code + ":" + "power").getBytes());
+        final RoomModifyRequest request = new RoomModifyRequest(Status.START);
 
         //when
         RestAssured.given().log().all()
@@ -93,14 +93,14 @@ class RoomControllerTest {
                 .statusCode(HttpStatus.OK.value());
 
         //then
-        Room room = roomManager.findByCode(code);
+        final Room room = roomManager.findByCode(code);
         Assertions.assertThat(room.getStatus()).isEqualTo(Status.START);
     }
 
     @Test
     void 방에_참가할_수_있다() {
         //given
-        String code = roomManager.create(new RoomInfo(5, 1, 1, 1));
+        final String code = roomManager.create(new RoomInfo(5, 1, 1, 1));
 
         //when
         RestAssured.given().log().all()
@@ -110,15 +110,15 @@ class RoomControllerTest {
                 .statusCode(HttpStatus.OK.value());
 
         //then
-        Room room = roomManager.findByCode(code);
+        final Room room = roomManager.findByCode(code);
         Assertions.assertThat(room.getPlayers()).containsKey("power");
     }
 
     @Test
     void 방의_코드를_찾는다() {
         // given
-        String code = roomManager.create(new RoomInfo(5, 1, 1, 1));
-        String basic = Base64.getEncoder().encodeToString((code + ":" + "power").getBytes());
+        final String code = roomManager.create(new RoomInfo(5, 1, 1, 1));
+        final String basic = Base64.getEncoder().encodeToString((code + ":" + "power").getBytes());
 
         // when & then
         RestAssured.given().log().all()


### PR DESCRIPTION
#11 방 코드 반환 로직구현 입니다.

- Room API 시작을 /room -> /rooms로 바껴서 이거 반영도 했습니다
- roomManager까지 갈 필요가 없는게 cookie의 code만 복호화해주면 되서 바로 반환하면 되더라고요.
- 원래 RoomCreateResponse였는데 이거랑 반환하는 필드가 똑같아서 재활용 할겸 RoomCodeResponse로 이름을 바꿨습니다.
