### PR TITLE
fix: NONE 싱글톤 에러 픽스

### DIFF
--- a/src/main/java/mafia/mafiatogether/domain/Room.java
+++ b/src/main/java/mafia/mafiatogether/domain/Room.java
@@ -89,7 +89,7 @@ public class Room {
     public String executeSkill(final String name, final String targetName) {
         final Player player = getPlayer(name);
         final Player target = getPlayer(targetName);
-        if (!target.isAlive()) {
+        if (!target.isAlive() && !target.equals(Player.NONE)) {
             throw new PlayerException(ExceptionCode.NOT_ALIVE_PLAYER);
         }
         return player.getJob().applySkill(target, jobTarget);


### PR DESCRIPTION
이전 PR 에서 Player.NONE이 싱글톤이면서 문제가 발생
이름을 빈칸으로 반환시 Player.NONE을 반환하면서 문제가 발생
```java
    public Player getPlayer(final String name) {
        if (name.isBlank()) {
            return Player.NONE;
        }
        if (!players.containsKey(name)) {
            throw new RoomException(ExceptionCode.INVALID_PLAYER);
        }
        return players.get(name);
    }
```
이전에 어떠한 이유로 Player.NONE을 사망처리하였을때 (투표 기권으로 Player.NONE이 사망 등) Player.NONE이 싱글톤으로 모든 상황에서 사망처리되어 
```java
    public String executeSkill(final String name, final String targetName) {
        final Player player = getPlayer(name);
        final Player target = getPlayer(targetName);
        if (!target.isAlive()) {
            throw new PlayerException(ExceptionCode.NOT_ALIVE_PLAYER);
        }
        return player.getJob().applySkill(target, jobTarget);
    }
```
에서 사망처리됨
그래서 일단 이 부분을 
```java
    public String executeSkill(final String name, final String targetName) {
        final Player player = getPlayer(name);
        final Player target = getPlayer(targetName);
        if (!target.isAlive() && !target.equals(Player.NONE)) {
            throw new PlayerException(ExceptionCode.NOT_ALIVE_PLAYER);
        }
        return player.getJob().applySkill(target, jobTarget);
    }
```
으로 바꿔둠
더 좋은 방법이 있는지 (있다면 getName을 따로 쓰는 방법인거 같은데) 잘 모르겠음...
