### PR TITLE
feat: RoomInfo에서 본인 직업은 보이게 변경

### DIFF
--- a/src/main/java/mafia/mafiatogether/service/dto/PlayerResponse.java
+++ b/src/main/java/mafia/mafiatogether/service/dto/PlayerResponse.java
@@ -17,6 +17,14 @@ public record PlayerResponse(
         );
     }
 
+    public static PlayerResponse forMyJob(final Player player) {
+        return new PlayerResponse(
+                player.getName(),
+                player.isAlive(),
+                player.getJobType()
+        );
+    }
+
     public static PlayerResponse forAlive(final Player player) {
         return new PlayerResponse(
                 player.getName(),

--- a/src/main/java/mafia/mafiatogether/service/dto/RoomInfoResponse.java
+++ b/src/main/java/mafia/mafiatogether/service/dto/RoomInfoResponse.java
@@ -3,6 +3,7 @@ package mafia.mafiatogether.service.dto;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import mafia.mafiatogether.domain.Player;
 import mafia.mafiatogether.domain.Room;
 
@@ -32,19 +33,24 @@ public record RoomInfoResponse(
         );
     }
 
-    private static List<PlayerResponse> convertFrom(final Player player, final Map<String, Player> players) {
-        if (!player.isAlive()) {
-            return players.values().stream()
-                    .map(PlayerResponse::forDead)
-                    .toList();
+    private static List<PlayerResponse> convertFrom(final Player owner, final Map<String, Player> players) {
+        PlayerResponse myJob = PlayerResponse.forMyJob(players.get(owner.getName()));
+        List<PlayerResponse> responses = players.values().stream()
+                .filter(it -> !it.getName().equals(owner.getName()))
+                .map(it -> playerToResponse(owner, it))
+                .collect(Collectors.toList());
+        responses.add(myJob);
+        return responses;
+    }
+
+    private static PlayerResponse playerToResponse(final Player owner, final Player player) {
+        if (!owner.isAlive()) {
+            return PlayerResponse.forDead(player);
         }
-        if (player.isMafia()) {
-            return players.values().stream()
-                    .map(PlayerResponse::forMafia)
-                    .toList();
+        if (owner.isMafia()) {
+            return PlayerResponse.forMafia(player);
         }
-        return players.values().stream()
-                .map(PlayerResponse::forAlive)
-                .toList();
+        return PlayerResponse.forAlive(player);
+
     }
 }

--- a/src/main/java/mafia/mafiatogether/service/dto/RoomInfoResponse.java
+++ b/src/main/java/mafia/mafiatogether/service/dto/RoomInfoResponse.java
@@ -36,8 +36,8 @@ public record RoomInfoResponse(
     private static List<PlayerResponse> convertFrom(final Player owner, final Map<String, Player> players) {
         PlayerResponse myJob = PlayerResponse.forMyJob(players.get(owner.getName()));
         List<PlayerResponse> responses = players.values().stream()
-                .filter(it -> !it.getName().equals(owner.getName()))
-                .map(it -> playerToResponse(owner, it))
+                .filter(response -> !response.getName().equals(owner.getName()))
+                .map(response -> playerToResponse(owner, response))
                 .collect(Collectors.toList());
         responses.add(myJob);
         return responses;
@@ -51,6 +51,5 @@ public record RoomInfoResponse(
             return PlayerResponse.forMafia(player);
         }
         return PlayerResponse.forAlive(player);
-
     }
 }

--- a/src/test/java/mafia/mafiatogether/controller/RoomControllerTest.java
+++ b/src/test/java/mafia/mafiatogether/controller/RoomControllerTest.java
@@ -15,6 +15,7 @@ import mafia.mafiatogether.domain.RoomInfo;
 import mafia.mafiatogether.domain.RoomManager;
 import mafia.mafiatogether.domain.job.JobType;
 import mafia.mafiatogether.domain.status.StatusType;
+import mafia.mafiatogether.service.dto.PlayerResponse;
 import mafia.mafiatogether.service.dto.RoomCodeResponse;
 import mafia.mafiatogether.service.dto.RoomCreateRequest;
 import mafia.mafiatogether.service.dto.RoomInfoResponse;
@@ -266,6 +267,7 @@ class RoomControllerTest {
         final String basic = Base64.getEncoder().encodeToString((code + ":" + "power").getBytes());
         final Room room = roomManager.findByCode(code);
         room.joinPlayer("power");
+        room.joinPlayer("chunsik");
 
         // when & then
         final RoomInfoResponse response = RestAssured.given().log().all()
@@ -277,6 +279,16 @@ class RoomControllerTest {
                 .extract()
                 .as(RoomInfoResponse.class);
 
+        PlayerResponse power = response.players()
+                .stream().filter(player -> player.name().equals("power"))
+                .findFirst()
+                .get();
+
+        PlayerResponse chunsik = response.players()
+                .stream().filter(player -> player.name().equals("chunsik"))
+                .findFirst()
+                .get();
+
         assertSoftly(
                 softly -> {
                     softly.assertThat(response.startTime()).isNotNull();
@@ -284,7 +296,8 @@ class RoomControllerTest {
                     softly.assertThat(response.myName()).isNotNull();
                     softly.assertThat(response.isAlive()).isTrue();
                     softly.assertThat(response.isMaster()).isTrue();
-                    softly.assertThat(response.players().getFirst().job()).isNull();
+                    softly.assertThat(power.job()).isEqualTo(JobType.CITIZEN);
+                    softly.assertThat(chunsik.job()).isNull();
                 }
         );
     }


### PR DESCRIPTION
- #74 

RoomInfo에서 본인 직업은 보이게 변경

지금은 이렇게 하고 나중에 리팩토링으로 DTO에있는 비즈니스로직을 Room쪽으로 옮기던가 하면 좋을듯함

살아있을때 보이고, 마피아끼리 보이고, 자기 자신의 직업 보이고, 죽었을때 직업 전부보이고 <- 이런 로직이 비즈니스로직이라고 생각되는데 DTO에있음,,,