### PR TITLE
fix: 초기 마피아 값 NULL, 이후 안죽이기시 빈 문자열로 수정

### DIFF
--- a/src/main/java/mafia/mafiatogether/domain/Room.java
+++ b/src/main/java/mafia/mafiatogether/domain/Room.java
@@ -98,7 +98,7 @@ public class Room {
     public String getJobsTarget(final String name) {
         final Player player = players.get(name);
         final JobType jobType = player.getJobType();
-        return jobTarget.getTarget(jobType).getName();
+        return jobTarget.getTargetName(jobType);
     }
 
     public void votePlayer(final String name, final String targetName, final Long now) {

--- a/src/main/java/mafia/mafiatogether/domain/job/JobTarget.java
+++ b/src/main/java/mafia/mafiatogether/domain/job/JobTarget.java
@@ -21,11 +21,11 @@ public class JobTarget {
         targets.put(jobType, player);
     }
 
-    public Player getTarget(final JobType jobType) {
+    public String getTargetName(final JobType jobType) {
         if (!targets.containsKey(jobType)) {
-            return Player.NONE;
+            return null;
         }
-        return targets.get(jobType);
+        return targets.get(jobType).getName();
     }
 
     public void execute() {

--- a/src/main/java/mafia/mafiatogether/domain/job/Police.java
+++ b/src/main/java/mafia/mafiatogether/domain/job/Police.java
@@ -1,5 +1,6 @@
 package mafia.mafiatogether.domain.job;
 
+import java.util.Objects;
 import mafia.mafiatogether.config.exception.ExceptionCode;
 import mafia.mafiatogether.config.exception.PlayerException;
 import mafia.mafiatogether.domain.Player;
@@ -8,7 +9,7 @@ public class Police implements Job {
 
     @Override
     public String applySkill(final Player player, final JobTarget jobTarget) {
-        if (jobTarget.getTarget(JobType.POLICE) != Player.NONE) {
+        if (Objects.nonNull(jobTarget.getTargetName(JobType.POLICE))) {
             throw new PlayerException(ExceptionCode.POLICE_DUPLICATE_SKILL);
         }
         jobTarget.addTarget(JobType.POLICE, player);


### PR DESCRIPTION
close #78 
구현하면서 JobTarget의 getTarget이 주는 값이 굳이 Player를 줄 필요없이 이름만 줘도 되는 로직이라 String으로 이름을 반환하게 수정하였습니다.