### PR TITLE
fix : Game save 조건 추가

### DIFF
--- a/src/main/java/mafia/mafiatogether/game/application/GameService.java
+++ b/src/main/java/mafia/mafiatogether/game/application/GameService.java
@@ -38,7 +38,7 @@ public class GameService {
     private StatusType checkStatusChanged(final Game game) {
         game.setStatsSnapshot();
         final StatusType statusType = game.getStatusType(Clock.systemDefaultZone().millis());
-        if (game.isStatusChanged()) {
+        if (game.isStatusChanged() && game.isNotDeleted()) {
             gameRepository.save(game);
         }
         return statusType;

--- a/src/main/java/mafia/mafiatogether/game/domain/Game.java
+++ b/src/main/java/mafia/mafiatogether/game/domain/Game.java
@@ -145,4 +145,8 @@ public class Game extends AbstractAggregateRoot<Game> {
     public boolean isStatusChanged() {
         return !statusSnapshot.getType().equals(status.getType());
     }
+
+    public boolean isNotDeleted(){
+        return !status.getType().equals(StatusType.WAIT);
+    }
 }

--- a/src/main/java/mafia/mafiatogether/game/domain/Game.java
+++ b/src/main/java/mafia/mafiatogether/game/domain/Game.java
@@ -147,6 +147,6 @@ public class Game extends AbstractAggregateRoot<Game> {
     }
 
     public boolean isNotDeleted(){
-        return !status.getType().equals(StatusType.WAIT);
+        return !status.getType().equals(StatusType.DELETED);
     }
 }

--- a/src/main/java/mafia/mafiatogether/game/domain/status/DeletedStatus.java
+++ b/src/main/java/mafia/mafiatogether/game/domain/status/DeletedStatus.java
@@ -15,6 +15,6 @@ public class DeletedStatus extends Status{
 
     @Override
     public StatusType getType() {
-        throw new RoomException(ExceptionCode.DELETED_STATUS);
+        return StatusType.WAIT;
     }
 }

--- a/src/main/java/mafia/mafiatogether/game/domain/status/DeletedStatus.java
+++ b/src/main/java/mafia/mafiatogether/game/domain/status/DeletedStatus.java
@@ -15,6 +15,6 @@ public class DeletedStatus extends Status{
 
     @Override
     public StatusType getType() {
-        return StatusType.WAIT;
+        return StatusType.DELETED;
     }
 }

--- a/src/main/java/mafia/mafiatogether/game/domain/status/StatusType.java
+++ b/src/main/java/mafia/mafiatogether/game/domain/status/StatusType.java
@@ -10,5 +10,6 @@ public enum StatusType {
     VOTE_RESULT,
     NIGHT_INTRO,
     NIGHT,
-    END
+    END,
+    DELETED
 }


### PR DESCRIPTION
문제 원인 :
EndStatus.getNextStatus를 하면서 game delete 이벤트를 발행 하는데 이때 return으로 다음 상태를 주면서 snapshot의 Status 상태와 달라져서 save가 일어남나게 되었습니다.

이 때문에 예외처리하는 상태가 저장되게 되면서 (원래는 지워졌어야할) 계속 예외처리를 하게 되는 오류였습니다.

DeletedStatus.getType에 반환값을 주고 (Wait) 이거 면 저장 로직에서 제외시켜 주었습니다.

ps. 이벤트 랑 레디스 때문에 진짜 돌려보면 생기는 버그가 많네요;;;;이번엔 이것도 직접 QA해봤습니다 진짜임