### PR TITLE
fix : 이벤트 발행을 위한 redis delete 요청 추가

### DIFF
--- a/src/main/java/mafia/mafiatogether/game/application/GameService.java
+++ b/src/main/java/mafia/mafiatogether/game/application/GameService.java
@@ -39,6 +39,7 @@ public class GameService {
         game.setStatsSnapshot();
         final StatusType statusType = game.getStatusType(Clock.systemDefaultZone().millis());
         if (game.isDeleted()){
+            gameRepository.delete(game);
             return StatusType.WAIT;
         }
         if (game.isStatusChanged()) {

--- a/src/main/java/mafia/mafiatogether/game/application/GameService.java
+++ b/src/main/java/mafia/mafiatogether/game/application/GameService.java
@@ -38,7 +38,10 @@ public class GameService {
     private StatusType checkStatusChanged(final Game game) {
         game.setStatsSnapshot();
         final StatusType statusType = game.getStatusType(Clock.systemDefaultZone().millis());
-        if (game.isStatusChanged() && game.isNotDeleted()) {
+        if (game.isDeleted()){
+            return StatusType.WAIT;
+        }
+        if (game.isStatusChanged()) {
             gameRepository.save(game);
         }
         return statusType;

--- a/src/main/java/mafia/mafiatogether/game/domain/Game.java
+++ b/src/main/java/mafia/mafiatogether/game/domain/Game.java
@@ -146,7 +146,7 @@ public class Game extends AbstractAggregateRoot<Game> {
         return !statusSnapshot.getType().equals(status.getType());
     }
 
-    public boolean isNotDeleted(){
-        return !status.getType().equals(StatusType.DELETED);
+    public boolean isDeleted() {
+        return status.getType().equals(StatusType.DELETED);
     }
 }


### PR DESCRIPTION
close #93 

## 원인 : 
1. DELETE 상태에서도 반환값으로 DELETE를 보내면서 프론트에서는 처리를 안한던 상태가 가게되어 에러 발생
2. DELETE 상태에서 redis에 요청을 안하게 되면서 이벤트 트리거가 발생하지 않아 delete 이벤트가 작동하지 않았고 이로 인해 game이 삭제되지 않음

## 해결 : 
1. DELETE 상태일때 WAIT을 보내주어 대기방으로 가게 유도
2. DELETE 상태일 경우 game을 삭제시켜주면서 이벤트 트리거 작동

ps. 이번엔 reids까지 다 확인했음 진짜임
그리고 진짜로 테스트 함 손보죠 이거 이대로는 안된다....