### PR TITLE
hotfix : NIGHT 결과로 게임 종료시 NOTICE 이후 ENDSTATE로 가게 수정

### DIFF
--- a/src/main/java/mafia/mafiatogether/game/domain/status/NightStatus.java
+++ b/src/main/java/mafia/mafiatogether/game/domain/status/NightStatus.java
@@ -19,9 +19,6 @@ public class NightStatus extends Status {
     @Override
     public Status getNextStatus(final Game game, final Long now) {
         game.publishJobExecuteEvent();
-        if (game.isEnd()) {
-            return EndStatus.create(now);
-        }
         return DayIntroStatus.create(now);
     }
 

--- a/src/main/java/mafia/mafiatogether/game/domain/status/NoticeStatus.java
+++ b/src/main/java/mafia/mafiatogether/game/domain/status/NoticeStatus.java
@@ -19,6 +19,9 @@ public class NoticeStatus extends Status {
     @Override
     public Status getNextStatus(final Game game, final Long now) {
         game.publishClearJobTargetEvent();
+        if (game.isEnd()) {
+            return EndStatus.create(now);
+        }
         return DayStatus.create(game.getAlivePlayerCount(), now);
     }
 

--- a/src/test/java/mafia/mafiatogether/game/domain/status/StatusTest.java
+++ b/src/test/java/mafia/mafiatogether/game/domain/status/StatusTest.java
@@ -85,7 +85,8 @@ class StatusTest {
     @Test
     void 밤_이후_게임종료_조건달성시_게임이_종료된다() {
         // given
-        final Long endTime = nightEndTime + 1_000L;
+        final Long nextNoticeTime = nextDay + 3_000L;
+        final Long endTime = nextNoticeTime + 3_000L;
         game.getStatusType(noticeTime);
         game.getStatusType(dayTime);
         game.getStatusType(voteTime);
@@ -94,6 +95,8 @@ class StatusTest {
         game.getStatusType(nightTime);
         game.getPlayer(PLAYER1).kill();
         game.getPlayer(PLAYER2).kill();
+        game.getStatusType(nextDay);
+        game.getStatusType(nextNoticeTime);
 
         // when & then
         Assertions.assertThat(game.getStatusType(endTime)).isEqualTo(StatusType.END);


### PR DESCRIPTION
close #97
그냥 endStatus로 가는 분기 로직인
```java
        if (game.isEnd()) {
            return EndStatus.create(now);
        }
```
을 

NightStatus.getNextStatus() 에서 NoticeStatus.getNextSatus()