### PR TITLE
게임 상태 변경 스케쥴러 구현 및 게임 SSE 로직 구현

### DIFF
--- a/src/main/java/mafia/mafiatogether/game/application/GameService.java
+++ b/src/main/java/mafia/mafiatogether/game/application/GameService.java
@@ -99,7 +99,8 @@ public class GameService {
         return sseEmitter;
     }
 
-    @Scheduled(fixedDelay = 5000L)
+    @Scheduled(fixedDelay = 500L)
+    @Transactional
     public void changeStatus(){
         for (Game game : gameRepository.findAll()) {
             checkStatusChanged(game);

--- a/src/main/java/mafia/mafiatogether/game/application/GameService.java
+++ b/src/main/java/mafia/mafiatogether/game/application/GameService.java
@@ -15,6 +15,7 @@ import mafia.mafiatogether.game.domain.SseEmitterRepository;
 import mafia.mafiatogether.game.domain.status.StatusType;
 import mafia.mafiatogether.lobby.domain.Lobby;
 import mafia.mafiatogether.lobby.domain.LobbyRepository;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -96,5 +97,12 @@ public class GameService {
         );
         sseEmitterRepository.save(code, sseEmitter);
         return sseEmitter;
+    }
+
+    @Scheduled(fixedDelay = 5000L)
+    public void changeStatus(){
+        for (Game game : gameRepository.findAll()) {
+            checkStatusChanged(game);
+        }
     }
 }

--- a/src/main/java/mafia/mafiatogether/game/application/GameService.java
+++ b/src/main/java/mafia/mafiatogether/game/application/GameService.java
@@ -25,6 +25,8 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEvent
 @RequiredArgsConstructor
 public class GameService {
 
+    private static final String SSE_STATUS = "gameStatus";
+    private static final String SSE_CONNECT_DATA = "connect";
     private final LobbyRepository lobbyRepository;
     private final GameRepository gameRepository;
     private final SseEmitterRepository sseEmitterRepository;
@@ -97,8 +99,8 @@ public class GameService {
 
     private SseEventBuilder getSseEvent() {
         return SseEmitter.event()
-                .name("gameStatus")
-                .data("connect")
+                .name(SSE_STATUS)
+                .data(SSE_CONNECT_DATA)
                 .reconnectTime(30_000L);
     }
 

--- a/src/main/java/mafia/mafiatogether/game/application/GameService.java
+++ b/src/main/java/mafia/mafiatogether/game/application/GameService.java
@@ -19,6 +19,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
 
 @Service
 @RequiredArgsConstructor
@@ -89,14 +90,16 @@ public class GameService {
 
     public SseEmitter subscribe(final String code) throws IOException {
         SseEmitter sseEmitter = new SseEmitter(43200_000L);
-        sseEmitter.send(
-                SseEmitter.event()
-                        .name("test")
-                        .data("connect")
-                        .reconnectTime(30_000L)
-        );
+        sseEmitter.send(getSseEvent());
         sseEmitterRepository.save(code, sseEmitter);
         return sseEmitter;
+    }
+
+    private SseEventBuilder getSseEvent() {
+        return SseEmitter.event()
+                .name("gameStatus")
+                .data("connect")
+                .reconnectTime(30_000L);
     }
 
     @Scheduled(fixedDelay = 500L)

--- a/src/main/java/mafia/mafiatogether/game/application/dto/event/GameStatusChangeEvent.java
+++ b/src/main/java/mafia/mafiatogether/game/application/dto/event/GameStatusChangeEvent.java
@@ -1,0 +1,9 @@
+package mafia.mafiatogether.game.application.dto.event;
+
+import mafia.mafiatogether.game.domain.status.StatusType;
+
+public record GameStatusChangeEvent(
+        String code,
+        StatusType statusType
+) {
+}

--- a/src/main/java/mafia/mafiatogether/game/domain/Game.java
+++ b/src/main/java/mafia/mafiatogether/game/domain/Game.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import mafia.mafiatogether.game.application.dto.event.ClearJobTargetEvent;
 import mafia.mafiatogether.game.application.dto.event.ClearVoteEvent;
 import mafia.mafiatogether.game.application.dto.event.DeleteGameEvent;
+import mafia.mafiatogether.game.application.dto.event.GameStatusChangeEvent;
 import mafia.mafiatogether.game.application.dto.event.JobExecuteEvent;
 import mafia.mafiatogether.game.application.dto.event.StartGameEvent;
 import mafia.mafiatogether.game.application.dto.event.VoteExecuteEvent;
@@ -66,6 +67,7 @@ public class Game extends AbstractAggregateRoot<Game> {
     public StatusType getStatusType(final Long now) {
         if (status.isTimeOver(now)) {
             status = status.getNextStatus(this, now);
+            registerEvent(new GameStatusChangeEvent(this.code, status.getType()));
         }
         return status.getType();
     }

--- a/src/main/java/mafia/mafiatogether/game/domain/InMemorySseEmitterRepository.java
+++ b/src/main/java/mafia/mafiatogether/game/domain/InMemorySseEmitterRepository.java
@@ -1,0 +1,26 @@
+package mafia.mafiatogether.game.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Repository
+public class InMemorySseEmitterRepository implements SseEmitterRepository {
+
+    private final Map<String, List<SseEmitter>> emitters;
+
+    public InMemorySseEmitterRepository() {
+        this.emitters = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public void save(final String code, final SseEmitter sseEmitter) {
+        if (!emitters.containsKey(code)) {
+            emitters.put(code, new ArrayList<>());
+        }
+        emitters.get(code).add(sseEmitter);
+    }
+}

--- a/src/main/java/mafia/mafiatogether/game/domain/InMemorySseEmitterRepository.java
+++ b/src/main/java/mafia/mafiatogether/game/domain/InMemorySseEmitterRepository.java
@@ -23,4 +23,9 @@ public class InMemorySseEmitterRepository implements SseEmitterRepository {
         }
         emitters.get(code).add(sseEmitter);
     }
+
+    @Override
+    public List<SseEmitter> get(String code) {
+        return emitters.get(code);
+    }
 }

--- a/src/main/java/mafia/mafiatogether/game/domain/SseEmitterRepository.java
+++ b/src/main/java/mafia/mafiatogether/game/domain/SseEmitterRepository.java
@@ -1,0 +1,9 @@
+package mafia.mafiatogether.game.domain;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface SseEmitterRepository {
+
+
+    void save(final String code, final SseEmitter sseEmitter);
+}

--- a/src/main/java/mafia/mafiatogether/game/domain/SseEmitterRepository.java
+++ b/src/main/java/mafia/mafiatogether/game/domain/SseEmitterRepository.java
@@ -1,9 +1,12 @@
 package mafia.mafiatogether.game.domain;
 
+import java.util.List;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 public interface SseEmitterRepository {
 
 
     void save(final String code, final SseEmitter sseEmitter);
+
+    List<SseEmitter> get(final String code);
 }

--- a/src/main/java/mafia/mafiatogether/game/ui/GameController.java
+++ b/src/main/java/mafia/mafiatogether/game/ui/GameController.java
@@ -1,5 +1,6 @@
 package mafia.mafiatogether.game.ui;
 
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import mafia.mafiatogether.config.PlayerInfo;
 import mafia.mafiatogether.game.application.GameService;
@@ -7,11 +8,13 @@ import mafia.mafiatogether.config.PlayerInfoDto;
 import mafia.mafiatogether.game.application.dto.response.GameInfoResponse;
 import mafia.mafiatogether.game.application.dto.response.GameResultResponse;
 import mafia.mafiatogether.game.application.dto.response.GameStatusResponse;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequiredArgsConstructor
@@ -47,5 +50,12 @@ public class GameController {
             @PlayerInfo PlayerInfoDto playerInfoDto
     ) {
         return ResponseEntity.ok(gameService.findGameInfo(playerInfoDto.code(), playerInfoDto.name()));
+    }
+
+    @GetMapping(path = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(
+            @PlayerInfo final PlayerInfoDto playerInfoDto
+    ) throws IOException {
+        return gameService.subscribe(playerInfoDto.code());
     }
 }

--- a/src/main/java/mafia/mafiatogether/game/ui/GameController.java
+++ b/src/main/java/mafia/mafiatogether/game/ui/GameController.java
@@ -53,9 +53,9 @@ public class GameController {
     }
 
     @GetMapping(path = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribe(
+    public ResponseEntity<SseEmitter> subscribe(
             @PlayerInfo final PlayerInfoDto playerInfoDto
     ) throws IOException {
-        return gameService.subscribe(playerInfoDto.code());
+        return ResponseEntity.ok(gameService.subscribe(playerInfoDto.code()));
     }
 }

--- a/src/test/java/mafia/mafiatogether/game/application/GameServiceTest.java
+++ b/src/test/java/mafia/mafiatogether/game/application/GameServiceTest.java
@@ -1,0 +1,132 @@
+package mafia.mafiatogether.game.application;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+
+import io.restassured.RestAssured;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import mafia.mafiatogether.game.domain.Game;
+import mafia.mafiatogether.game.domain.GameRepository;
+import mafia.mafiatogether.game.domain.PlayerCollection;
+import mafia.mafiatogether.game.domain.SseEmitterRepository;
+import mafia.mafiatogether.game.domain.status.DayIntroStatus;
+import mafia.mafiatogether.game.domain.status.StatusType;
+import mafia.mafiatogether.global.RedisTestConfig;
+import mafia.mafiatogether.job.domain.JobTarget;
+import mafia.mafiatogether.job.domain.JobTargetRepository;
+import mafia.mafiatogether.lobby.domain.Lobby;
+import mafia.mafiatogether.lobby.domain.LobbyInfo;
+import mafia.mafiatogether.lobby.domain.LobbyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+
+@Import(RedisTestConfig.class)
+@SuppressWarnings("NonAsciiCharacters")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class GameServiceTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    protected LobbyRepository lobbyRepository;
+
+    @Autowired
+    protected GameRepository gameRepository;
+
+    @Autowired
+    private GameService gameService;
+
+    @MockBean
+    private SseEmitterRepository sseEmitterRepository;
+
+    @MockBean
+    private JobTargetRepository jobTargetRepository;
+
+    private static Game STATUSCHANGEDGAME;
+    private static Game NOTCHANGEDGAME;
+    private static Long now;
+
+    @BeforeEach
+    void setPort() {
+        RestAssured.port = port;
+    }
+
+    @BeforeEach
+    void setGames() {
+        now = Clock.systemDefaultZone().millis();
+        STATUSCHANGEDGAME = new Game(
+                "STATUSCHANGEDGAME",
+                DayIntroStatus.create(now - 10_000L),
+                LobbyInfo.of(5, 2, 1, 1),
+                "master",
+                new PlayerCollection(),
+                DayIntroStatus.create(now - 10_000L)
+        );
+        NOTCHANGEDGAME = new Game(
+                "NOTCHANGEDGAME",
+                DayIntroStatus.create(now + 10_000L),
+                LobbyInfo.of(5, 2, 1, 1),
+                "master",
+                new PlayerCollection(),
+                DayIntroStatus.create(now + 10_000L)
+        );
+        lobbyRepository.save(Lobby.create(STATUSCHANGEDGAME.getCode(), LobbyInfo.of(5, 2, 1, 1)));
+        lobbyRepository.save(Lobby.create(NOTCHANGEDGAME.getCode(), LobbyInfo.of(5, 2, 1, 1)));
+        gameRepository.save(STATUSCHANGEDGAME);
+        gameRepository.save(NOTCHANGEDGAME);
+    }
+
+    @Test
+    void 스케쥴러에_의해_방의_시간이_변경된다() {
+        // given
+        JobTarget mockedJobTarget = Mockito.mock(JobTarget.class);
+        Mockito.when(sseEmitterRepository.get(any())).thenReturn(List.of());
+        Mockito.when(jobTargetRepository.findById(any())).thenReturn(Optional.of(mockedJobTarget));
+
+        // when & then
+        await().atMost(Duration.ofMillis(4_000L))
+                .untilAsserted(() -> assertStatusType());
+    }
+
+    private void assertStatusType() {
+        final StatusType actualChanged = gameRepository.findById(STATUSCHANGEDGAME.getCode()).get().getStatus()
+                .getType();
+        final StatusType actualNotChanged = gameRepository.findById(NOTCHANGEDGAME.getCode()).get().getStatus()
+                .getType();
+
+        assertSoftly(
+                softly -> {
+                    softly.assertThat(actualChanged).isEqualTo(StatusType.NOTICE);
+                    softly.assertThat(actualNotChanged).isEqualTo(StatusType.DAY_INTRO);
+                }
+        );
+    }
+
+    @Test
+    void 상태가_변경시_이벤트가_발행된다() throws IOException {
+        // given
+        JobTarget mockedJobTarget = Mockito.mock(JobTarget.class);
+        Mockito.when(sseEmitterRepository.get(any())).thenReturn(List.of());
+        Mockito.when(jobTargetRepository.findById(any())).thenReturn(Optional.of(mockedJobTarget));
+
+        // when
+        gameService.changeStatus();
+
+        // then
+        Mockito.verify(sseEmitterRepository, Mockito.times(1)).get(STATUSCHANGEDGAME.getCode());
+        Mockito.verify(sseEmitterRepository, Mockito.times(0)).get(NOTCHANGEDGAME.getCode());
+    }
+}

--- a/src/test/java/mafia/mafiatogether/game/domain/status/StatusTest.java
+++ b/src/test/java/mafia/mafiatogether/game/domain/status/StatusTest.java
@@ -100,6 +100,5 @@ class StatusTest {
 
         // when & then
         Assertions.assertThat(game.getStatusType(endTime)).isEqualTo(StatusType.END);
-
     }
 }

--- a/src/test/java/mafia/mafiatogether/lobby/application/LobbyRemoveTest.java
+++ b/src/test/java/mafia/mafiatogether/lobby/application/LobbyRemoveTest.java
@@ -1,6 +1,5 @@
 package mafia.mafiatogether.lobby.application;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -15,10 +14,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest
+@SuppressWarnings("NonAsciiCharacters")
 class LobbyRemoveTest {
 
     @MockBean
     private LobbyRepository lobbyRepository;
+
     @Autowired
     private LobbyRemoveService lobbyRemoveService;
 


### PR DESCRIPTION
close #111 

우선 SSE 테스트의 경우 너무 외부 의존적이라 테스트 코드 짜기 애매해서 일단 Postman으로 테스트 해보았습니다

/games/subscribe를 통해 구독을 하고
게임상태가 변경시 해당 방 상태를 구독하고 있는 사람들에게 뿌리도록 구현했습니다.
또한 스케쥴러 0.5초를 주기로 계속 돌리면서 상태의 시간이 넘겼는지 체크하고 변할경우 변경하여 저장해주고 있습니다.

테스트의 경우 스케쥴러를 통해 방 상태가 변경되는지 테스트와 방 상태 변경시 이벤트가 발행되는지 테스트하였습니다.