### PR TITLE
refactor : SSE 리펙터링 및 Test 환경 Scheduler에 의한 테스트 지연 및 예외처리 상황 개선

### DIFF
--- a/src/main/java/mafia/mafiatogether/MafiaTogetherApplication.java
+++ b/src/main/java/mafia/mafiatogether/MafiaTogetherApplication.java
@@ -2,14 +2,11 @@ package mafia.mafiatogether;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableScheduling
 public class MafiaTogetherApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(MafiaTogetherApplication.class, args);
     }
-
 }

--- a/src/main/java/mafia/mafiatogether/common/config/RedisConfig.java
+++ b/src/main/java/mafia/mafiatogether/common/config/RedisConfig.java
@@ -20,7 +20,7 @@ public class RedisConfig {
     @Value("${spring.data.redis.host}")
     private String host;
 
-    @Value(("${spring.data.redis.port}"))
+    @Value("${spring.data.redis.port}")
     private int port;
 
     @Bean
@@ -63,5 +63,4 @@ public class RedisConfig {
 
         return container;
     }
-
 }

--- a/src/main/java/mafia/mafiatogether/common/config/RedisConfig.java
+++ b/src/main/java/mafia/mafiatogether/common/config/RedisConfig.java
@@ -17,10 +17,10 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @EnableRedisRepositories
 public class RedisConfig {
 
-    @Value("${spring.redis.host}")
+    @Value("${spring.data.redis.host}")
     private String host;
 
-    @Value(("${spring.redis.port}"))
+    @Value(("${spring.data.redis.port}"))
     private int port;
 
     @Bean

--- a/src/main/java/mafia/mafiatogether/common/config/SchedulerConfig.java
+++ b/src/main/java/mafia/mafiatogether/common/config/SchedulerConfig.java
@@ -1,0 +1,11 @@
+package mafia.mafiatogether.common.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@ConditionalOnProperty(value = "application.scheduling-enable", havingValue = "true", matchIfMissing = false)
+public class SchedulerConfig {
+}

--- a/src/main/java/mafia/mafiatogether/common/config/WebMvcConfig.java
+++ b/src/main/java/mafia/mafiatogether/common/config/WebMvcConfig.java
@@ -1,13 +1,13 @@
 package mafia.mafiatogether.common.config;
 
-import java.util.List;
-
 import mafia.mafiatogether.common.resolver.PlayerArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
@@ -20,7 +20,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("https://mafia-together.com", "http://localhost:5173", "https://localhost:5173")
+                .allowedOrigins("https://dev.mafia-together.com", "https://mafia-together.com", "http://localhost:5173", "https://localhost:5173")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 .allowCredentials(true)
                 .exposedHeaders(HttpHeaders.LOCATION);

--- a/src/main/java/mafia/mafiatogether/common/config/WebMvcConfig.java
+++ b/src/main/java/mafia/mafiatogether/common/config/WebMvcConfig.java
@@ -20,7 +20,12 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("https://dev.mafia-together.com", "https://mafia-together.com", "http://localhost:5173", "https://localhost:5173")
+                .allowedOrigins(
+                        "https://dev.mafia-together.com",
+                        "https://mafia-together.com",
+                        "http://localhost:5173",
+                        "https://localhost:5173"
+                )
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 .allowCredentials(true)
                 .exposedHeaders(HttpHeaders.LOCATION);

--- a/src/main/java/mafia/mafiatogether/common/config/WebSocketConfig.java
+++ b/src/main/java/mafia/mafiatogether/common/config/WebSocketConfig.java
@@ -19,7 +19,13 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/stomp");
+        registry.addEndpoint("/stomp")
+                .setAllowedOrigins(
+                        "https://dev.mafia-together.com",
+                        "https://mafia-together.com",
+                        "http://localhost:5173",
+                        "https://localhost:5173"
+                );
     }
 
     @Override

--- a/src/main/java/mafia/mafiatogether/game/annotation/SseSubscribe.java
+++ b/src/main/java/mafia/mafiatogether/game/annotation/SseSubscribe.java
@@ -1,0 +1,8 @@
+package mafia.mafiatogether.game.annotation;
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface SseSubscribe {
+}

--- a/src/main/java/mafia/mafiatogether/game/annotation/SseSubscribe.java
+++ b/src/main/java/mafia/mafiatogether/game/annotation/SseSubscribe.java
@@ -3,6 +3,5 @@ import java.lang.annotation.*;
 
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-@Documented
 public @interface SseSubscribe {
 }

--- a/src/main/java/mafia/mafiatogether/game/application/GameEventListener.java
+++ b/src/main/java/mafia/mafiatogether/game/application/GameEventListener.java
@@ -1,22 +1,11 @@
 package mafia.mafiatogether.game.application;
 
-import java.io.IOException;
-import java.time.Clock;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import mafia.mafiatogether.chat.domain.Chat;
 import mafia.mafiatogether.chat.domain.ChatRepository;
 import mafia.mafiatogether.common.exception.ExceptionCode;
 import mafia.mafiatogether.common.exception.GameException;
-import mafia.mafiatogether.game.application.dto.event.ClearJobTargetEvent;
-import mafia.mafiatogether.game.application.dto.event.ClearVoteEvent;
-import mafia.mafiatogether.game.application.dto.event.DeleteGameEvent;
-import mafia.mafiatogether.game.application.dto.event.GameStatusChangeEvent;
-import mafia.mafiatogether.game.application.dto.event.JobExecuteEvent;
-import mafia.mafiatogether.game.application.dto.event.StartGameEvent;
-import mafia.mafiatogether.game.application.dto.event.VoteExecuteEvent;
+import mafia.mafiatogether.game.application.dto.event.*;
 import mafia.mafiatogether.game.application.dto.response.GameStatusResponse;
 import mafia.mafiatogether.game.domain.Game;
 import mafia.mafiatogether.game.domain.GameRepository;
@@ -37,6 +26,12 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -109,6 +104,7 @@ public class GameEventListener {
         jobTargetRepository.deleteById(deleteGameEvent.code());
         chatRepository.deleteById(deleteGameEvent.code());
         voteRepository.deleteById(deleteGameEvent.code());
+        sseEmitterRepository.deleteByCode(deleteGameEvent.code());
         gameRepository.deleteById(deleteGameEvent.code());
 
         final Lobby room = lobbyRepository.findById(deleteGameEvent.code())
@@ -138,6 +134,7 @@ public class GameEventListener {
         jobTargetRepository.deleteById(deleteLobbyEvent.code());
         chatRepository.deleteById(deleteLobbyEvent.code());
         voteRepository.deleteById(deleteLobbyEvent.code());
+        sseEmitterRepository.deleteByCode(deleteLobbyEvent.code());
         gameRepository.deleteById(deleteLobbyEvent.code());
         lobbyRepository.deleteById(deleteLobbyEvent.code());
     }

--- a/src/main/java/mafia/mafiatogether/game/application/GameEventListener.java
+++ b/src/main/java/mafia/mafiatogether/game/application/GameEventListener.java
@@ -148,7 +148,7 @@ public class GameEventListener {
     }
 
     private void sendStatusChangeEventToSseClient(final String code, final StatusType statusType) throws IOException {
-        List<SseEmitter> emitters = sseEmitterRepository.get(code);
+        List<SseEmitter> emitters = sseEmitterRepository.findByCode(code);
         for (SseEmitter emitter : emitters) {
             emitter.send(getSseEvent(statusType));
         }

--- a/src/main/java/mafia/mafiatogether/game/application/GameService.java
+++ b/src/main/java/mafia/mafiatogether/game/application/GameService.java
@@ -1,9 +1,5 @@
 package mafia.mafiatogether.game.application;
 
-import java.io.IOException;
-import java.time.Clock;
-import java.util.Optional;
-
 import lombok.RequiredArgsConstructor;
 import mafia.mafiatogether.common.exception.ExceptionCode;
 import mafia.mafiatogether.common.exception.GameException;
@@ -12,24 +8,22 @@ import mafia.mafiatogether.game.application.dto.response.GameResultResponse;
 import mafia.mafiatogether.game.application.dto.response.GameStatusResponse;
 import mafia.mafiatogether.game.domain.Game;
 import mafia.mafiatogether.game.domain.GameRepository;
-import mafia.mafiatogether.game.domain.SseEmitterRepository;
 import mafia.mafiatogether.game.domain.status.StatusType;
 import mafia.mafiatogether.lobby.domain.Lobby;
 import mafia.mafiatogether.lobby.domain.LobbyRepository;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
+
+import java.time.Clock;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class GameService {
 
-    private static final String SSE_STATUS = "gameStatus";
     private final LobbyRepository lobbyRepository;
     private final GameRepository gameRepository;
-    private final SseEmitterRepository sseEmitterRepository;
 
     @Transactional
     public GameStatusResponse findStatus(final String code) {
@@ -88,30 +82,6 @@ public class GameService {
             throw new GameException(ExceptionCode.GAME_IS_NOT_FINISHED);
         }
         return GameResultResponse.from(game);
-    }
-
-    @Transactional
-    public SseEmitter subscribe(final String code, final String name) throws IOException {
-        SseEmitter sseEmitter = new SseEmitter(43200_000L);
-        sseEmitter.send(getSseEvent(code));
-        sseEmitter.onCompletion(() -> sseEmitterRepository.deleteByCodeAndEmitter(code, name));
-        sseEmitter.onTimeout(sseEmitter::complete);
-        sseEmitterRepository.save(code, name, sseEmitter);
-        return sseEmitter;
-    }
-
-    private SseEventBuilder getSseEvent(final String code) {
-        Optional<Game> game = gameRepository.findById(code);
-        if (game.isPresent()) {
-            return SseEmitter.event()
-                    .name(SSE_STATUS)
-                    .data(new GameStatusResponse(game.get().getStatus().getType()))
-                    .reconnectTime(30_000L);
-        }
-        return SseEmitter.event()
-                .name(SSE_STATUS)
-                .data(new GameStatusResponse(StatusType.WAIT))
-                .reconnectTime(30_000L);
     }
 
     @Scheduled(fixedDelay = 500L)

--- a/src/main/java/mafia/mafiatogether/game/aspect/SseService.java
+++ b/src/main/java/mafia/mafiatogether/game/aspect/SseService.java
@@ -1,0 +1,91 @@
+package mafia.mafiatogether.game.aspect;
+
+import lombok.RequiredArgsConstructor;
+import mafia.mafiatogether.common.annotation.PlayerInfo;
+import mafia.mafiatogether.common.exception.AuthException;
+import mafia.mafiatogether.common.exception.ExceptionCode;
+import mafia.mafiatogether.common.resolver.PlayerInfoDto;
+import mafia.mafiatogether.game.application.dto.response.GameStatusResponse;
+import mafia.mafiatogether.game.domain.Game;
+import mafia.mafiatogether.game.domain.GameRepository;
+import mafia.mafiatogether.game.domain.SseEmitterRepository;
+import mafia.mafiatogether.game.domain.status.StatusType;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class SseService {
+
+    private static final String SSE_STATUS = "gameStatus";
+    public static final long HOURS_12 = 43200_000L;
+    public static final long SECOND_30 = 30_000L;
+    private final SseEmitterRepository sseEmitterRepository;
+    private final GameRepository gameRepository;
+
+    @Around("@annotation(mafia.mafiatogether.game.annotation.SseSubscribe)")
+    public ResponseEntity<SseEmitter> subscribe(final ProceedingJoinPoint joinPoint) throws Throwable {
+
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+        Method method = methodSignature.getMethod();
+
+        Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+        Object[] args = joinPoint.getArgs();
+
+        String[] codeAndName = new String[2];
+        for (int i = 0; i < parameterAnnotations.length; i++) {
+            findCodeOrName(parameterAnnotations[i], args[i], codeAndName);
+        }
+
+        String code = codeAndName[0];
+        String name = codeAndName[1];
+        SseEmitter sseEmitter = createSseEmitter(code, name);
+        sseEmitterRepository.save(code, name, sseEmitter);
+        return ResponseEntity.ok(sseEmitter);
+    }
+
+    private void findCodeOrName(Annotation[] annotations, Object argument, String[] codeAndName) {
+        for (Annotation annotation : annotations) {
+            if (!(annotation instanceof PlayerInfo)) {
+                continue;
+            }
+            PlayerInfoDto playerInfoDto = (PlayerInfoDto) argument;
+            codeAndName[0] = playerInfoDto.code();
+            codeAndName[1] = playerInfoDto.name();
+            return;
+        }
+        throw new AuthException(ExceptionCode.INVALID_AUTHENTICATION_FORM);
+    }
+
+    private SseEmitter createSseEmitter(String code, String name) throws IOException {
+        SseEmitter sseEmitter = new SseEmitter(HOURS_12);
+        sseEmitter.send(getSseEvent(code));
+        sseEmitter.onCompletion(() -> sseEmitterRepository.deleteByCodeAndEmitter(code, name));
+        sseEmitter.onTimeout(sseEmitter::complete);
+        return sseEmitter;
+    }
+
+    private SseEmitter.SseEventBuilder getSseEvent(final String code) {
+        Optional<Game> game = gameRepository.findById(code);
+        return game.map(value -> getSseEventBuilder(value.getStatus().getType()))
+                .orElseGet(() -> getSseEventBuilder(StatusType.WAIT));
+    }
+
+    private static SseEmitter.SseEventBuilder getSseEventBuilder(final StatusType statusType) {
+        return SseEmitter.event()
+                .name(SSE_STATUS)
+                .data(new GameStatusResponse(statusType))
+                .reconnectTime(SECOND_30);
+    }
+}

--- a/src/main/java/mafia/mafiatogether/game/domain/InMemorySseEmitterRepository.java
+++ b/src/main/java/mafia/mafiatogether/game/domain/InMemorySseEmitterRepository.java
@@ -25,7 +25,20 @@ public class InMemorySseEmitterRepository implements SseEmitterRepository {
     }
 
     @Override
-    public List<SseEmitter> get(String code) {
+    public List<SseEmitter> findByCode(String code) {
+        if (!emitters.containsKey(code)) {
+            return new ArrayList<>();
+        }
         return emitters.get(code);
+    }
+
+    @Override
+    public void deleteByCode(String code) {
+        emitters.remove(code);
+    }
+
+    @Override
+    public void deleteByCodeAndEmitter(String code, SseEmitter sseEmitter) {
+        emitters.get(code).remove(sseEmitter);
     }
 }

--- a/src/main/java/mafia/mafiatogether/game/domain/InMemorySseEmitterRepository.java
+++ b/src/main/java/mafia/mafiatogether/game/domain/InMemorySseEmitterRepository.java
@@ -4,24 +4,25 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Repository
 public class InMemorySseEmitterRepository implements SseEmitterRepository {
 
-    private final Map<String, List<SseEmitter>> emitters;
+    private final Map<String, Map<String, SseEmitter>> emitters;
 
     public InMemorySseEmitterRepository() {
         this.emitters = new ConcurrentHashMap<>();
     }
 
     @Override
-    public void save(final String code, final SseEmitter sseEmitter) {
+    public void save(final String code, final String name, final SseEmitter sseEmitter) {
         if (!emitters.containsKey(code)) {
-            emitters.put(code, new ArrayList<>());
+            emitters.put(code, new ConcurrentHashMap<>());
         }
-        emitters.get(code).add(sseEmitter);
+        emitters.get(code).put(name, sseEmitter);
     }
 
     @Override
@@ -29,7 +30,7 @@ public class InMemorySseEmitterRepository implements SseEmitterRepository {
         if (!emitters.containsKey(code)) {
             return new ArrayList<>();
         }
-        return emitters.get(code);
+        return emitters.get(code).values().stream().toList();
     }
 
     @Override
@@ -38,7 +39,10 @@ public class InMemorySseEmitterRepository implements SseEmitterRepository {
     }
 
     @Override
-    public void deleteByCodeAndEmitter(String code, SseEmitter sseEmitter) {
-        emitters.get(code).remove(sseEmitter);
+    public void deleteByCodeAndEmitter(String code, final String name) {
+        if (!emitters.containsKey(code)) {
+            return;
+        }
+        emitters.get(code).remove(name);
     }
 }

--- a/src/main/java/mafia/mafiatogether/game/domain/SseEmitterRepository.java
+++ b/src/main/java/mafia/mafiatogether/game/domain/SseEmitterRepository.java
@@ -1,16 +1,17 @@
 package mafia.mafiatogether.game.domain;
 
 import java.util.List;
+
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 public interface SseEmitterRepository {
 
 
-    void save(final String code, final SseEmitter sseEmitter);
+    void save(final String code, final String name, final SseEmitter sseEmitter);
 
     List<SseEmitter> findByCode(final String code);
 
     void deleteByCode(final String code);
 
-    void deleteByCodeAndEmitter(final String code, final SseEmitter sseEmitter);
+    void deleteByCodeAndEmitter(final String code, final String name);
 }

--- a/src/main/java/mafia/mafiatogether/game/domain/SseEmitterRepository.java
+++ b/src/main/java/mafia/mafiatogether/game/domain/SseEmitterRepository.java
@@ -8,5 +8,9 @@ public interface SseEmitterRepository {
 
     void save(final String code, final SseEmitter sseEmitter);
 
-    List<SseEmitter> get(final String code);
+    List<SseEmitter> findByCode(final String code);
+
+    void deleteByCode(final String code);
+
+    void deleteByCodeAndEmitter(final String code, final SseEmitter sseEmitter);
 }

--- a/src/main/java/mafia/mafiatogether/game/domain/status/StatusType.java
+++ b/src/main/java/mafia/mafiatogether/game/domain/status/StatusType.java
@@ -12,4 +12,5 @@ public enum StatusType {
     NIGHT,
     END,
     DELETED
+
 }

--- a/src/main/java/mafia/mafiatogether/game/ui/GameController.java
+++ b/src/main/java/mafia/mafiatogether/game/ui/GameController.java
@@ -1,6 +1,7 @@
 package mafia.mafiatogether.game.ui;
 
 import java.io.IOException;
+
 import lombok.RequiredArgsConstructor;
 import mafia.mafiatogether.common.annotation.PlayerInfo;
 import mafia.mafiatogether.game.application.GameService;
@@ -57,7 +58,7 @@ public class GameController {
     public ResponseEntity<SseEmitter> subscribe(
             @PlayerInfo final PlayerInfoDto playerInfoDto
     ) throws IOException {
-        return ResponseEntity.ok(gameService.subscribe(playerInfoDto.code()));
+        return ResponseEntity.ok(gameService.subscribe(playerInfoDto.code(), playerInfoDto.name()));
     }
 
 

--- a/src/main/java/mafia/mafiatogether/game/ui/GameController.java
+++ b/src/main/java/mafia/mafiatogether/game/ui/GameController.java
@@ -1,11 +1,10 @@
 package mafia.mafiatogether.game.ui;
 
-import java.io.IOException;
-
 import lombok.RequiredArgsConstructor;
 import mafia.mafiatogether.common.annotation.PlayerInfo;
-import mafia.mafiatogether.game.application.GameService;
 import mafia.mafiatogether.common.resolver.PlayerInfoDto;
+import mafia.mafiatogether.game.annotation.SseSubscribe;
+import mafia.mafiatogether.game.application.GameService;
 import mafia.mafiatogether.game.application.dto.response.GameExistResponse;
 import mafia.mafiatogether.game.application.dto.response.GameInfoResponse;
 import mafia.mafiatogether.game.application.dto.response.GameResultResponse;
@@ -55,12 +54,10 @@ public class GameController {
     }
 
     @GetMapping(path = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<SseEmitter> subscribe(
-            @PlayerInfo final PlayerInfoDto playerInfoDto
-    ) throws IOException {
-        return ResponseEntity.ok(gameService.subscribe(playerInfoDto.code(), playerInfoDto.name()));
+    @SseSubscribe
+    public ResponseEntity<SseEmitter> subscribe(@PlayerInfo final PlayerInfoDto playerInfoDto) {
+        return ResponseEntity.ok(new SseEmitter());
     }
-
 
     @GetMapping("/valid")
     public ResponseEntity<GameExistResponse> isValid(

--- a/src/test/java/mafia/mafiatogether/game/application/GameEventListenerTest.java
+++ b/src/test/java/mafia/mafiatogether/game/application/GameEventListenerTest.java
@@ -240,7 +240,7 @@ class GameEventListenerTest extends ControllerTest {
         final String target = PLAYER1_NAME;
         game.skipStatus(Clock.systemDefaultZone().millis()); // NOTICE
         game.skipStatus(Clock.systemDefaultZone().millis()); // DAY
-        Mockito.when(sseEmitterRepository.get(any())).thenReturn(List.of());
+        Mockito.when(sseEmitterRepository.findByCode(any())).thenReturn(List.of());
         gameRepository.save(game);
 
         // when
@@ -254,6 +254,6 @@ class GameEventListenerTest extends ControllerTest {
         // then
         final StatusType actual = gameRepository.findById(CODE).get().getStatus().getType();
         Assertions.assertThat(actual).isEqualTo(StatusType.VOTE);
-        Mockito.verify(sseEmitterRepository, Mockito.atLeast(1)).get(CODE);
+        Mockito.verify(sseEmitterRepository, Mockito.atLeast(1)).findByCode(CODE);
     }
 }

--- a/src/test/java/mafia/mafiatogether/game/application/GameServiceTest.java
+++ b/src/test/java/mafia/mafiatogether/game/application/GameServiceTest.java
@@ -1,22 +1,12 @@
 package mafia.mafiatogether.game.application;
 
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.awaitility.Awaitility.await;
-import static org.mockito.ArgumentMatchers.any;
-
-import io.restassured.RestAssured;
-
-import java.time.Clock;
-import java.time.Duration;
-import java.util.List;
-import java.util.Optional;
 import mafia.mafiatogether.game.domain.Game;
 import mafia.mafiatogether.game.domain.GameRepository;
 import mafia.mafiatogether.game.domain.PlayerCollection;
 import mafia.mafiatogether.game.domain.SseEmitterRepository;
 import mafia.mafiatogether.game.domain.status.DayIntroStatus;
 import mafia.mafiatogether.game.domain.status.StatusType;
-import mafia.mafiatogether.global.RedisTestConfig;
+import mafia.mafiatogether.global.RedisTestContainerSpringBootTest;
 import mafia.mafiatogether.job.domain.JobTarget;
 import mafia.mafiatogether.job.domain.JobTargetRepository;
 import mafia.mafiatogether.lobby.domain.Lobby;
@@ -26,19 +16,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.context.annotation.Import;
 
-@Import(RedisTestConfig.class)
+import java.io.IOException;
+import java.time.Clock;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+
 @SuppressWarnings("NonAsciiCharacters")
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-public class GameServiceTest {
-
-    @LocalServerPort
-    private int port;
+public class GameServiceTest extends RedisTestContainerSpringBootTest {
 
     @Autowired
     protected LobbyRepository lobbyRepository;
@@ -58,11 +47,6 @@ public class GameServiceTest {
     private static Game STATUSCHANGEDGAME;
     private static Game NOTCHANGEDGAME;
     private static Long now;
-
-    @BeforeEach
-    void setPort() {
-        RestAssured.port = port;
-    }
 
     @BeforeEach
     void setGames() {
@@ -97,11 +81,7 @@ public class GameServiceTest {
         Mockito.when(jobTargetRepository.findById(any())).thenReturn(Optional.of(mockedJobTarget));
 
         // when & then
-        await().atMost(Duration.ofMillis(4_000L))
-                .untilAsserted(() -> assertStatusType());
-    }
-
-    private void assertStatusType() {
+        gameService.changeStatus();
         final StatusType actualChanged = gameRepository.findById(STATUSCHANGEDGAME.getCode()).get().getStatus()
                 .getType();
         final StatusType actualNotChanged = gameRepository.findById(NOTCHANGEDGAME.getCode()).get().getStatus()
@@ -115,18 +95,18 @@ public class GameServiceTest {
         );
     }
 
-//    @Test
-//    void 상태가_변경시_이벤트가_발행된다() throws IOException {
-//        // given
-//        JobTarget mockedJobTarget = Mockito.mock(JobTarget.class);
-//        Mockito.when(sseEmitterRepository.get(any())).thenReturn(List.of());
-//        Mockito.when(jobTargetRepository.findById(any())).thenReturn(Optional.of(mockedJobTarget));
-//
-//        // when
-//        gameService.changeStatus();
-//
-//        // then
-//        Mockito.verify(sseEmitterRepository, Mockito.times(1)).get(STATUSCHANGEDGAME.getCode());
-//        Mockito.verify(sseEmitterRepository, Mockito.times(0)).get(NOTCHANGEDGAME.getCode());
-//    }
+    @Test
+    void 상태가_변경시_이벤트가_발행된다() throws IOException {
+        // given
+        JobTarget mockedJobTarget = Mockito.mock(JobTarget.class);
+        Mockito.when(sseEmitterRepository.findByCode(any())).thenReturn(List.of());
+        Mockito.when(jobTargetRepository.findById(any())).thenReturn(Optional.of(mockedJobTarget));
+
+        // when
+        gameService.changeStatus();
+
+        // then
+        Mockito.verify(sseEmitterRepository, Mockito.times(1)).findByCode(STATUSCHANGEDGAME.getCode());
+        Mockito.verify(sseEmitterRepository, Mockito.times(0)).findByCode(NOTCHANGEDGAME.getCode());
+    }
 }

--- a/src/test/java/mafia/mafiatogether/game/application/GameServiceTest.java
+++ b/src/test/java/mafia/mafiatogether/game/application/GameServiceTest.java
@@ -5,7 +5,7 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 
 import io.restassured.RestAssured;
-import java.io.IOException;
+
 import java.time.Clock;
 import java.time.Duration;
 import java.util.List;
@@ -93,7 +93,7 @@ public class GameServiceTest {
     void 스케쥴러에_의해_방의_시간이_변경된다() {
         // given
         JobTarget mockedJobTarget = Mockito.mock(JobTarget.class);
-        Mockito.when(sseEmitterRepository.get(any())).thenReturn(List.of());
+        Mockito.when(sseEmitterRepository.findByCode(any())).thenReturn(List.of());
         Mockito.when(jobTargetRepository.findById(any())).thenReturn(Optional.of(mockedJobTarget));
 
         // when & then

--- a/src/test/java/mafia/mafiatogether/game/ui/GameControllerTest.java
+++ b/src/test/java/mafia/mafiatogether/game/ui/GameControllerTest.java
@@ -1,12 +1,7 @@
 package mafia.mafiatogether.game.ui;
 
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.hamcrest.Matchers.equalTo;
-
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import java.util.Base64;
-import java.util.Map;
 import mafia.mafiatogether.common.exception.ErrorResponse;
 import mafia.mafiatogether.common.exception.ExceptionCode;
 import mafia.mafiatogether.game.application.dto.response.GameInfoResponse;
@@ -21,6 +16,12 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+
+import java.util.Base64;
+import java.util.Map;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.hamcrest.Matchers.equalTo;
 
 @SuppressWarnings("NonAsciiCharacters")
 class GameControllerTest extends ControllerTest {

--- a/src/test/java/mafia/mafiatogether/global/ControllerTest.java
+++ b/src/test/java/mafia/mafiatogether/global/ControllerTest.java
@@ -2,8 +2,6 @@ package mafia.mafiatogether.global;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import java.util.Base64;
-import java.util.Map;
 import mafia.mafiatogether.game.domain.GameRepository;
 import mafia.mafiatogether.game.domain.PlayerCollection;
 import mafia.mafiatogether.game.domain.status.StatusType;
@@ -13,20 +11,13 @@ import mafia.mafiatogether.lobby.domain.LobbyInfo;
 import mafia.mafiatogether.lobby.domain.LobbyRepository;
 import mafia.mafiatogether.vote.domain.VoteRepository;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 
-@Import(RedisTestConfig.class)
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-public abstract class ControllerTest {
+import java.util.Base64;
+import java.util.Map;
 
-    @LocalServerPort
-    private int port;
+public abstract class ControllerTest extends RedisTestContainerSpringBootTest{
 
     @Autowired
     protected LobbyRepository lobbyRepository;
@@ -49,10 +40,6 @@ public abstract class ControllerTest {
     protected String POLICE;
     protected String CITIZEN;
 
-    @BeforeEach
-    void setPort() {
-        RestAssured.port = port;
-    }
 
     protected void setLobby() {
         final Lobby lobby = Lobby.create(CODE, LobbyInfo.of(5, 2, 1, 1));

--- a/src/test/java/mafia/mafiatogether/global/RedisTestConfig.java
+++ b/src/test/java/mafia/mafiatogether/global/RedisTestConfig.java
@@ -4,6 +4,8 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import java.time.Duration;
+
 @TestConfiguration
 public class RedisTestConfig {
 
@@ -12,11 +14,12 @@ public class RedisTestConfig {
     static {
         GenericContainer<?> REDIS_CONTAINER = new GenericContainer<>(DockerImageName.parse(REDIS_DOCKER_IMAGE))
                 .withExposedPorts(6379)
+                .withStartupTimeout(Duration.ofSeconds(60))
                 .withReuse(true);
 
         REDIS_CONTAINER.start();
 
-        System.setProperty("spring.redis.host", REDIS_CONTAINER.getHost());
-        System.setProperty("spring.redis.port", REDIS_CONTAINER.getMappedPort(6379).toString());
+        System.setProperty("spring.data.redis.host", REDIS_CONTAINER.getHost());
+        System.setProperty("spring.data.redis.port", REDIS_CONTAINER.getMappedPort(6379).toString());
     }
 }

--- a/src/test/java/mafia/mafiatogether/global/RedisTestContainerSpringBootTest.java
+++ b/src/test/java/mafia/mafiatogether/global/RedisTestContainerSpringBootTest.java
@@ -1,0 +1,22 @@
+package mafia.mafiatogether.global;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+@Import(RedisTestConfig.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {"application.scheduling-enable=false"})
+public abstract class RedisTestContainerSpringBootTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setPort() {
+        RestAssured.port = port;
+    }
+}

--- a/src/test/java/mafia/mafiatogether/lobby/application/LobbyRemoveTest.java
+++ b/src/test/java/mafia/mafiatogether/lobby/application/LobbyRemoveTest.java
@@ -12,9 +12,11 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
 @SuppressWarnings("NonAsciiCharacters")
+@TestPropertySource(properties = {"application.scheduling-enable=false"})
 class LobbyRemoveTest {
 
     @MockBean


### PR DESCRIPTION
이거 제가 이슈 파는거 깜빡하고 진행했네여;;;;

## 스케쥴러에서 npe가 발생
---
1. Spring scheduler가 존재하는 모든 game을 가져옴
2. 상태 변경시 해당 `SseEmittersRepository.get(code)`를 통해 모든 list를 가져옴
3. `SseEmittersRepository`의 내부 구현을 `Map`으로 하다보니 없는 code에 대해선 null을 반환
    3.1. 재실행을 하거나 유령방 등 `SseEmittersRepository`에서 CODE는 삭재되고 Redis에는 game이 남아있을 경우 null 반환됨
4. npe 발생
해결 -> key가 존재 안할시 빈 리스트반환

## SseEmittersRepository 구현체 변경
---
`SseEmittersRepository`을 기존 `Map<String, List<SseEmitters>`였다면 지금은 `Map<String, Map<String, SseEmitters>>`로 교체
이유 : List로 존재시 해당 연결이 끊겼을때 찾아야할 로직이 복잡, 또한 재 접속시 단순히 key값에 대하여 sse 만 put해줘야 하기 때문에 편함

## Sse 연결 관리 aspect로 분리
---
서비스 단에서 http 연결을 관리한다는 것이 어색하다고 판단하여 aspect 로 분리 (thanks to mett...)

## Scheduler에 의한 테스트 실패
---
scheduler가 돌면서 계속 꺼진 redis에 접근하여 예외 발생
해결 : enableScheduler config를 만들고 특정 property에 대해서만 작동하게 변경
