### PR TITLE
feature : redis 락 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencyManagement {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.37.0'
     testImplementation 'org.testcontainers:testcontainers'
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -44,9 +45,6 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured:5.4.0'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
-
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'

--- a/src/main/java/mafia/mafiatogether/common/annotation/RedisLock.java
+++ b/src/main/java/mafia/mafiatogether/common/annotation/RedisLock.java
@@ -1,0 +1,32 @@
+package mafia.mafiatogether.common.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * 이 어노테이션은 서비스단에서 락대상을 정하는 메서드입니다.
+ * 해당 메서드에서 조회하는 모든 키에 대해 Lock을 거는 것이 아닌 특정 key에만 설정해줍니다.
+ * 또한 이 Lock이 어노테이션이 없는 대상은 해당 자원에 접근할 수 있습니다.
+ * 이 어노테이션은 이 어노테이션을 사용하는 메서드끼리만의 자원 접근을 막을 수 있습니다.
+ * <p>
+ * 이 어노테이션을 사용하는 메서드는 꼭 @RedisLockTarget을 사용하여 잠금 대상을 지정해주어야 합니다.
+ * <p>
+ * 작성자: waterricecake
+ * <p>
+ * 수정일시 : 20241021
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface RedisLock {
+    /**
+     * key()는 자원의 유니크한 키를 사용하기 위해 사용합니다.
+     * <pre>
+     *  ex) @RedisLock(key = "lobby") 를 사용할 경우 키는 "mafiatogether:lock:lobby"가 완성됩니다. 이후 뒤는 랜덤한 값(code)를 사용하여 유니크하게 유지합니다.
+     * </pre>
+     * <p>
+     * 작성자: waterricecake
+     * <p>
+     * 수정일시 : 20241021
+     */
+    String[] key();
+}

--- a/src/main/java/mafia/mafiatogether/common/annotation/RedisLock.java
+++ b/src/main/java/mafia/mafiatogether/common/annotation/RedisLock.java
@@ -8,10 +8,8 @@ import java.lang.annotation.*;
  * 또한 이 Lock이 어노테이션이 없는 대상은 해당 자원에 접근할 수 있습니다.
  * 이 어노테이션은 이 어노테이션을 사용하는 메서드끼리만의 자원 접근을 막을 수 있습니다.
  * <p>
- * 이 어노테이션을 사용하는 메서드는 꼭 {@link mafia.mafiatogether.common.annotation.RedisLockTarget}을 사용하여 잠금 대상을 지정해주어야 합니다.
- * <p>
  * 작성자: waterricecake
- * <p>
+ * </p>
  * 수정일시 : 20241021
  */
 @Target(ElementType.METHOD)
@@ -23,10 +21,13 @@ public @interface RedisLock {
      * <pre>
      *  ex) @RedisLock(key = "lobby") 를 사용할 경우 키는 "mafiatogether:lock:lobby"가 완성됩니다. 이후 뒤는 랜덤한 값(code)를 사용하여 유니크하게 유지합니다.
      * </pre>
+     * @exception mafia.mafiatogether.common.exception.ServerException if {@link mafia.mafiatogether.common.annotation.RedisLockTarget} not exists
      * <p>
      * 작성자: waterricecake
+     * </p>
      * <p>
      * 수정일시 : 20241021
+     * </p>
      */
     String[] key();
 }

--- a/src/main/java/mafia/mafiatogether/common/annotation/RedisLock.java
+++ b/src/main/java/mafia/mafiatogether/common/annotation/RedisLock.java
@@ -8,7 +8,7 @@ import java.lang.annotation.*;
  * 또한 이 Lock이 어노테이션이 없는 대상은 해당 자원에 접근할 수 있습니다.
  * 이 어노테이션은 이 어노테이션을 사용하는 메서드끼리만의 자원 접근을 막을 수 있습니다.
  * <p>
- * 이 어노테이션을 사용하는 메서드는 꼭 @RedisLockTarget을 사용하여 잠금 대상을 지정해주어야 합니다.
+ * 이 어노테이션을 사용하는 메서드는 꼭 {@link mafia.mafiatogether.common.annotation.RedisLockTarget}을 사용하여 잠금 대상을 지정해주어야 합니다.
  * <p>
  * 작성자: waterricecake
  * <p>

--- a/src/main/java/mafia/mafiatogether/common/annotation/RedisLockTarget.java
+++ b/src/main/java/mafia/mafiatogether/common/annotation/RedisLockTarget.java
@@ -1,0 +1,11 @@
+package mafia.mafiatogether.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RedisLockTarget {
+}

--- a/src/main/java/mafia/mafiatogether/common/annotation/RedisLockTarget.java
+++ b/src/main/java/mafia/mafiatogether/common/annotation/RedisLockTarget.java
@@ -1,10 +1,15 @@
 package mafia.mafiatogether.common.annotation;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
+/**
+ * 이 어노테이션은 {@link mafia.mafiatogether.common.annotation.RedisLock}을 사용한 메서드의 String파라미터에 사용됩니다
+ * <p>
+ * 작성자: waterricecake
+ * <p>
+ * 수정일시 : 20241021
+ */
+@Documented
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RedisLockTarget {

--- a/src/main/java/mafia/mafiatogether/common/annotation/RedisLockTarget.java
+++ b/src/main/java/mafia/mafiatogether/common/annotation/RedisLockTarget.java
@@ -3,7 +3,7 @@ package mafia.mafiatogether.common.annotation;
 import java.lang.annotation.*;
 
 /**
- * 이 어노테이션은 {@link mafia.mafiatogether.common.annotation.RedisLock}을 사용한 메서드의 String파라미터에 사용됩니다
+ * 이 어노테이션은 {@link mafia.mafiatogether.common.annotation.RedisLock}을 사용한 메서드의 String파라미터에 사용됩니다.
  * <p>
  * 작성자: waterricecake
  * <p>

--- a/src/main/java/mafia/mafiatogether/common/aspect/RedisLockAspect.java
+++ b/src/main/java/mafia/mafiatogether/common/aspect/RedisLockAspect.java
@@ -25,8 +25,8 @@ import java.util.concurrent.TimeUnit;
 public class RedisLockAspect {
 
     private static final String LOCK_KEY_PREFIX = "mafiatogether:lock:";
-    public static final int WAIT_TIME = 5;
-    public static final int LEASE_TIME = 15;
+    private static final int WAIT_TIME = 5;
+    private static final int LEASE_TIME = 15;
     private final RedissonClient redissonClient;
 
     @Around("@annotation(mafia.mafiatogether.common.annotation.RedisLock)")

--- a/src/main/java/mafia/mafiatogether/common/aspect/RedisLockAspect.java
+++ b/src/main/java/mafia/mafiatogether/common/aspect/RedisLockAspect.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 @Aspect
 @Component
 @RequiredArgsConstructor
-public class RedisTransactionAspect {
+public class RedisLockAspect {
 
     private static final String LOCK_KEY_PREFIX = "mafiatogether:lock:";
     public static final int WAIT_TIME = 5;

--- a/src/main/java/mafia/mafiatogether/common/aspect/RedisTransactionAspect.java
+++ b/src/main/java/mafia/mafiatogether/common/aspect/RedisTransactionAspect.java
@@ -1,0 +1,104 @@
+package mafia.mafiatogether.common.aspect;
+
+import lombok.RequiredArgsConstructor;
+import mafia.mafiatogether.common.annotation.RedisLockTarget;
+import mafia.mafiatogether.common.annotation.RedisLock;
+import mafia.mafiatogether.common.exception.ExceptionCode;
+import mafia.mafiatogether.common.exception.ServerException;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class RedisTransactionAspect {
+
+    private static final String LOCK_KEY_PREFIX = "mafiatogether:lock:";
+    public static final int WAIT_TIME = 5;
+    public static final int LEASE_TIME = 15;
+    private final RedissonClient redissonClient;
+
+    @Around("@annotation(mafia.mafiatogether.common.annotation.RedisLock)")
+    public Object lock(final ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        final String[] keys = getRedisLockKey(proceedingJoinPoint);
+        final RLock[] locks = getRLocks(keys);
+
+        boolean isLocked;
+
+        try {
+            isLocked = tryLockAll(locks);
+        } catch (InterruptedException e) {
+            throw new ServerException(ExceptionCode.GETTING_LOCK_FAIL_EXCEPTION);
+        }
+
+        if (!isLocked) {
+            throw new ServerException(ExceptionCode.GETTING_LOCK_FAIL_EXCEPTION);
+        }
+
+        try {
+            return proceedingJoinPoint.proceed();
+        } finally {
+            unlockAll(locks);
+        }
+    }
+
+    private String[] getRedisLockKey(ProceedingJoinPoint proceedingJoinPoint) {
+        MethodSignature signature = (MethodSignature) proceedingJoinPoint.getSignature();
+        Method method = signature.getMethod();
+        RedisLock redisLock = method.getAnnotation(RedisLock.class);
+
+        Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+        Object[] args = proceedingJoinPoint.getArgs();
+
+        for (int i = 0; i < parameterAnnotations.length; i++) {
+            if (hasTarget(parameterAnnotations[i])) {
+                return parsingToKeyList(redisLock.key(), args[i].toString());
+            }
+        }
+        throw new ServerException(ExceptionCode.LOCK_CODE_EXCEPTION);
+    }
+
+    private String[] parsingToKeyList(final String[] keys, final String target) {
+        for (int i = 0; i < keys.length; i++) {
+            keys[i] = LOCK_KEY_PREFIX + keys[i] + ":" + target;
+        }
+        return keys;
+    }
+
+    private RLock[] getRLocks(final String[] keys) {
+        RLock[] rLocks = new RLock[keys.length];
+        for (int i = 0; i < keys.length; i++) {
+            rLocks[i] = redissonClient.getLock(keys[i]);
+        }
+        return rLocks;
+    }
+
+    private boolean tryLockAll(final RLock[] rLocks) throws InterruptedException {
+        for (RLock rLock : rLocks) {
+            if(!rLock.tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void unlockAll(final RLock[] rLocks) {
+        for (RLock rLock : rLocks) {
+            rLock.unlock();
+        }
+    }
+
+    private boolean hasTarget(Annotation[] annotations) {
+        return Arrays.stream(annotations).anyMatch(RedisLockTarget.class::isInstance);
+    }
+}

--- a/src/main/java/mafia/mafiatogether/common/config/RedisConfig.java
+++ b/src/main/java/mafia/mafiatogether/common/config/RedisConfig.java
@@ -1,10 +1,12 @@
 package mafia.mafiatogether.common.config;
 
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
@@ -17,6 +19,8 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @EnableRedisRepositories
 public class RedisConfig {
 
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
     @Value("${spring.data.redis.host}")
     private String host;
 
@@ -24,8 +28,10 @@ public class RedisConfig {
     private int port;
 
     @Bean
-    public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(host, port);
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + host + ":" + port);
+        return Redisson.create(config);
     }
 
     @Bean

--- a/src/main/java/mafia/mafiatogether/common/exception/ExceptionCode.java
+++ b/src/main/java/mafia/mafiatogether/common/exception/ExceptionCode.java
@@ -30,7 +30,10 @@ public enum ExceptionCode {
 
     NOT_FOUND_REQUEST(300, "HttpServletRequest를 찾을 수 없습니다."),
     MISSING_AUTHENTICATION_HEADER(301, "인증 헤더가 없습니다."),
-    INVALID_AUTHENTICATION_FORM(302, "올바른 인증 형식이 아닙니다.");
+    INVALID_AUTHENTICATION_FORM(302, "올바른 인증 형식이 아닙니다."),
+
+    LOCK_CODE_EXCEPTION(501, "RedisLockTarget 파라미터를 찾을 수 없습니다."),
+    GETTING_LOCK_FAIL_EXCEPTION(502, "레디스 락을 얻는데 실패하였습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/mafia/mafiatogether/common/exception/ServerException.java
+++ b/src/main/java/mafia/mafiatogether/common/exception/ServerException.java
@@ -1,0 +1,7 @@
+package mafia.mafiatogether.common.exception;
+
+public class ServerException extends GlobalException{
+    public ServerException(final ExceptionCode exceptionCode) {
+        super(exceptionCode.getCode(), exceptionCode.getMessage());
+    }
+}

--- a/src/main/java/mafia/mafiatogether/lobby/application/LobbyService.java
+++ b/src/main/java/mafia/mafiatogether/lobby/application/LobbyService.java
@@ -1,6 +1,8 @@
 package mafia.mafiatogether.lobby.application;
 
 import lombok.RequiredArgsConstructor;
+import mafia.mafiatogether.common.annotation.RedisLock;
+import mafia.mafiatogether.common.annotation.RedisLockTarget;
 import mafia.mafiatogether.common.exception.ExceptionCode;
 import mafia.mafiatogether.common.exception.GameException;
 import mafia.mafiatogether.lobby.application.dto.request.LobbyCreateRequest;
@@ -22,7 +24,7 @@ public class LobbyService {
     @Transactional
     public LobbyCodeResponse create(final LobbyCreateRequest request) {
         String code = CodeGenerator.generate();
-        while (lobbyRepository.existsById(code)){
+        while (lobbyRepository.existsById(code)) {
             code = CodeGenerator.generate();
         }
         final LobbyInfo lobbyInfo = LobbyInfo.of(request.total(), request.mafia(), request.doctor(), request.police());
@@ -32,7 +34,8 @@ public class LobbyService {
     }
 
     @Transactional
-    public void join(final String code, final String name) {
+    @RedisLock(key = "lobby")
+    public void join(@RedisLockTarget final String code, final String name) {
         final Lobby lobby = lobbyRepository.findById(code)
                 .orElseThrow(() -> new GameException(ExceptionCode.INVALID_NOT_FOUND_ROOM_CODE));
         lobby.joinPlayer(name);

--- a/src/test/java/mafia/mafiatogether/lobby/ui/LobbyControllerTest.java
+++ b/src/test/java/mafia/mafiatogether/lobby/ui/LobbyControllerTest.java
@@ -27,13 +27,19 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 
+
+@Import(RedisLockTestLobbyService.class)
 @SuppressWarnings("NonAsciiCharacters")
 class LobbyControllerTest extends ControllerTest {
 
     @Autowired
     private LobbyRepository lobbyRepository;
+
+    @Autowired
+    private RedisLockTestLobbyService redisLockTestLobbyService;
 
     @BeforeEach
     void setTest() {
@@ -210,14 +216,13 @@ class LobbyControllerTest extends ControllerTest {
         lobby.joinPlayer("A");
         lobby.joinPlayer("B");
         lobbyRepository.save(lobby);
-        int count = 100;
+        int count = 2;
         ExecutorService executorService = Executors.newFixedThreadPool(count);
         CountDownLatch countDownLatch = new CountDownLatch(count);
 
         // when
         executorService.execute(
                 () -> {
-                    RedisLockTestLobbyService redisLockTestLobbyService = new RedisLockTestLobbyService(lobbyRepository);
                     try {
                         redisLockTestLobbyService.waitAndInput(CODE, expect);
                     } catch (Exception e) {
@@ -228,7 +233,7 @@ class LobbyControllerTest extends ControllerTest {
                 }
         );
 
-        Thread.sleep(500);
+        Thread.sleep(10);
 
         for (int i = 1; i < count; i++) {
             executorService.execute(

--- a/src/test/java/mafia/mafiatogether/lobby/ui/LobbyControllerTest.java
+++ b/src/test/java/mafia/mafiatogether/lobby/ui/LobbyControllerTest.java
@@ -2,9 +2,14 @@ package mafia.mafiatogether.lobby.ui;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+
 import java.util.Base64;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Stream;
+
 import mafia.mafiatogether.common.exception.ErrorResponse;
 import mafia.mafiatogether.common.exception.ExceptionCode;
 import mafia.mafiatogether.global.ControllerTest;
@@ -13,6 +18,7 @@ import mafia.mafiatogether.lobby.application.dto.response.LobbyCodeResponse;
 import mafia.mafiatogether.lobby.domain.Lobby;
 import mafia.mafiatogether.lobby.domain.LobbyInfo;
 import mafia.mafiatogether.lobby.domain.LobbyRepository;
+import mafia.mafiatogether.lobby.domain.Participant;
 import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
@@ -31,13 +37,13 @@ class LobbyControllerTest extends ControllerTest {
     private LobbyRepository lobbyRepository;
 
     @BeforeEach
-    void setTest(){
-        final Lobby lobby = Lobby.create(CODE, LobbyInfo.of(3,1,1,1));
+    void setTest() {
+        final Lobby lobby = Lobby.create(CODE, LobbyInfo.of(3, 1, 1, 1));
         lobbyRepository.save(lobby);
     }
 
     @AfterEach
-    void clearTest(){
+    void clearTest() {
         lobbyRepository.deleteById(CODE);
     }
 
@@ -195,5 +201,54 @@ class LobbyControllerTest extends ControllerTest {
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .body("exist", Matchers.equalTo(true));
+    }
+
+    @Test
+    void 방_한자리_남았을때_동시접근시_최초1인만_입장할_수_있다() throws InterruptedException {
+        // given
+        String expect = "C";
+        Lobby lobby = lobbyRepository.findById(CODE).get();
+        lobby.joinPlayer("A");
+        lobby.joinPlayer("B");
+        lobbyRepository.save(lobby);
+        int count = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(count);
+        CountDownLatch countDownLatch = new CountDownLatch(count);
+
+        // when
+        executorService.execute(
+                () -> {
+                    RedisLockTestLobbyService redisLockTestLobbyService = new RedisLockTestLobbyService(lobbyRepository);
+                    try {
+                        redisLockTestLobbyService.waitAndInput(CODE, expect);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    } finally {
+                        countDownLatch.countDown();
+                    }
+                }
+        );
+
+        Thread.sleep(500);
+
+        for (int i = 1; i < count; i++) {
+            executorService.execute(
+                    () -> {
+                        RestAssured.given().log().all()
+                                .contentType(ContentType.JSON)
+                                .when().get("/lobbies?code=" + CODE + "&name=power")
+                                .then().log().all();
+                        countDownLatch.countDown();
+                    }
+            );
+        }
+        countDownLatch.await();
+
+        final Lobby actual = lobbyRepository.findById(CODE).get();
+        System.out.println(actual.getParticipants().size());
+        for (Participant name : lobby.getParticipants().getParticipants()) {
+            System.out.println(name.getName());
+        }
+        Assertions.assertThat(actual.isParticipantExist(expect)).isTrue();
     }
 }

--- a/src/test/java/mafia/mafiatogether/lobby/ui/LobbyControllerTest.java
+++ b/src/test/java/mafia/mafiatogether/lobby/ui/LobbyControllerTest.java
@@ -18,7 +18,6 @@ import mafia.mafiatogether.lobby.application.dto.response.LobbyCodeResponse;
 import mafia.mafiatogether.lobby.domain.Lobby;
 import mafia.mafiatogether.lobby.domain.LobbyInfo;
 import mafia.mafiatogether.lobby.domain.LobbyRepository;
-import mafia.mafiatogether.lobby.domain.Participant;
 import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
@@ -245,10 +244,6 @@ class LobbyControllerTest extends ControllerTest {
         countDownLatch.await();
 
         final Lobby actual = lobbyRepository.findById(CODE).get();
-        System.out.println(actual.getParticipants().size());
-        for (Participant name : lobby.getParticipants().getParticipants()) {
-            System.out.println(name.getName());
-        }
         Assertions.assertThat(actual.isParticipantExist(expect)).isTrue();
     }
 }

--- a/src/test/java/mafia/mafiatogether/lobby/ui/RedisLockTestLobbyService.java
+++ b/src/test/java/mafia/mafiatogether/lobby/ui/RedisLockTestLobbyService.java
@@ -20,7 +20,6 @@ public class RedisLockTestLobbyService {
         Thread.sleep(50);
         final Lobby lobby = lobbyRepository.findById(code)
                 .orElseThrow(() -> new GameException(ExceptionCode.INVALID_NOT_FOUND_ROOM_CODE));
-        System.out.println("Wait and Input");
         lobby.joinPlayer(name);
         lobbyRepository.save(lobby);
     }

--- a/src/test/java/mafia/mafiatogether/lobby/ui/RedisLockTestLobbyService.java
+++ b/src/test/java/mafia/mafiatogether/lobby/ui/RedisLockTestLobbyService.java
@@ -7,16 +7,16 @@ import mafia.mafiatogether.common.exception.GameException;
 import mafia.mafiatogether.lobby.domain.Lobby;
 import mafia.mafiatogether.lobby.domain.LobbyRepository;
 
-public class RedisLockTestLobbyService {
+class RedisLockTestLobbyService {
 
     private final LobbyRepository lobbyRepository;
 
-    public RedisLockTestLobbyService(LobbyRepository lobbyRepository) {
+    protected RedisLockTestLobbyService(LobbyRepository lobbyRepository) {
         this.lobbyRepository = lobbyRepository;
     }
 
     @RedisLock(key = "lobby")
-    public void waitAndInput(@RedisLockTarget String code, String name) throws InterruptedException {
+    protected void waitAndInput(@RedisLockTarget String code, String name) throws InterruptedException {
         Thread.sleep(50);
         final Lobby lobby = lobbyRepository.findById(code)
                 .orElseThrow(() -> new GameException(ExceptionCode.INVALID_NOT_FOUND_ROOM_CODE));

--- a/src/test/java/mafia/mafiatogether/lobby/ui/RedisLockTestLobbyService.java
+++ b/src/test/java/mafia/mafiatogether/lobby/ui/RedisLockTestLobbyService.java
@@ -6,7 +6,9 @@ import mafia.mafiatogether.common.exception.ExceptionCode;
 import mafia.mafiatogether.common.exception.GameException;
 import mafia.mafiatogether.lobby.domain.Lobby;
 import mafia.mafiatogether.lobby.domain.LobbyRepository;
+import org.springframework.boot.test.context.TestComponent;
 
+@TestComponent
 class RedisLockTestLobbyService {
 
     private final LobbyRepository lobbyRepository;

--- a/src/test/java/mafia/mafiatogether/lobby/ui/RedisLockTestLobbyService.java
+++ b/src/test/java/mafia/mafiatogether/lobby/ui/RedisLockTestLobbyService.java
@@ -1,0 +1,27 @@
+package mafia.mafiatogether.lobby.ui;
+
+import mafia.mafiatogether.common.annotation.RedisLock;
+import mafia.mafiatogether.common.annotation.RedisLockTarget;
+import mafia.mafiatogether.common.exception.ExceptionCode;
+import mafia.mafiatogether.common.exception.GameException;
+import mafia.mafiatogether.lobby.domain.Lobby;
+import mafia.mafiatogether.lobby.domain.LobbyRepository;
+
+public class RedisLockTestLobbyService {
+
+    private final LobbyRepository lobbyRepository;
+
+    public RedisLockTestLobbyService(LobbyRepository lobbyRepository) {
+        this.lobbyRepository = lobbyRepository;
+    }
+
+    @RedisLock(key = "lobby")
+    public void waitAndInput(@RedisLockTarget String code, String name) throws InterruptedException {
+        Thread.sleep(50);
+        final Lobby lobby = lobbyRepository.findById(code)
+                .orElseThrow(() -> new GameException(ExceptionCode.INVALID_NOT_FOUND_ROOM_CODE));
+        System.out.println("Wait and Input");
+        lobby.joinPlayer(name);
+        lobbyRepository.save(lobby);
+    }
+}


### PR DESCRIPTION
close #138 

# 구현과정
Redisson으로 구현하였습니다.

또한 AOP 로 분리하여 해당 메서드에서 lock을 걸고 싶은 자원을 설정해주어야 합니다.

```java
    @Transactional
    @RedisLock(key = "lobby")
    public void join(@RedisLockTarget final String code, final String name) {
    ~~~~~
    로직
    ~~~~
```

이렇게 할경우
lobby:code 라는 잠금을 얻게 됩니다. 따라서 lobby:code라는 잠금을 획득하기 위해서는 이 잠금이 해재될때까지 대기하게 됩니다.

단점은 이 lock을 사용하지 않는 경우에는 lock에 안걸리고 걍 접근할 수 있다입니다. 

근데 이 부분은 redis의 장점을 위해서라도 모든 자원에 락을 걸지않고 꼭 필요한 동시성 이슈가 발생할 수 있는 부분에서만 거는 것이 맞지 않을까하여 이렇게 구현하였습니다.

또한 한 트랜젝션에서 여러 락을 얻고 싶을 수 도 있으니 `RedisLock`의 key를 배열로 받아 처리하도록 하였습니다.

구현 참고
![Redis Lock 구현](https://github.com/user-attachments/assets/f9ed2197-83a7-4a2f-ac0e-c3ff157df35e)

